### PR TITLE
File comparison is now "carriage return" insensitive

### DIFF
--- a/fs/manifest.go
+++ b/fs/manifest.go
@@ -24,7 +24,8 @@ type resource struct {
 
 type file struct {
 	resource
-	content io.ReadCloser
+	content             io.ReadCloser
+	ignoreCariageReturn bool
 }
 
 func (f *file) Type() string {

--- a/fs/path.go
+++ b/fs/path.go
@@ -127,6 +127,15 @@ func MatchAnyFileContent(path Path) error {
 	return nil
 }
 
+// MatchContentIgnoreCarriageReturn is a PathOp that ignores cariage return
+// discrepancies.
+func MatchContentIgnoreCarriageReturn(path Path) error {
+	if m, ok := path.(*filePath); ok {
+		m.file.ignoreCariageReturn = true
+	}
+	return nil
+}
+
 const anyFile = "*"
 
 // MatchExtraFiles is a PathOp that updates a Manifest to allow a directory

--- a/fs/report.go
+++ b/fs/report.go
@@ -67,6 +67,11 @@ func eqResource(x, y resource) []problem {
 	return p
 }
 
+func removeCarriageReturn(in []byte) []byte {
+	return bytes.Replace(in, []byte("\r\n"), []byte("\n"), -1)
+}
+
+// nolint: gocyclo
 func eqFile(x, y *file) []problem {
 	p := eqResource(x.resource, y.resource)
 
@@ -94,6 +99,10 @@ func eqFile(x, y *file) []problem {
 	}
 	if xErr != nil || yErr != nil {
 		return p
+	}
+	if x.ignoreCariageReturn || y.ignoreCariageReturn {
+		xContent = removeCarriageReturn(xContent)
+		yContent = removeCarriageReturn(yContent)
 	}
 
 	if !bytes.Equal(xContent, yContent) {

--- a/fs/report_test.go
+++ b/fs/report_test.go
@@ -108,6 +108,18 @@ func TestEqualWithFileContent(t *testing.T) {
 	assert.Equal(t, result.(cmpFailure).FailureMessage(), expected)
 }
 
+func TestEqualWithMatchContentIgnoreCarriageReturn(t *testing.T) {
+	dir := NewDir(t, t.Name(),
+		WithFile("file1", "line1\r\nline2"))
+	defer dir.Remove()
+
+	manifest := Expected(t,
+		WithFile("file1", "line1\nline2", MatchContentIgnoreCarriageReturn))
+
+	result := Equal(dir.Path(), manifest)()
+	assert.Assert(t, result.Success())
+}
+
 func TestEqualDirectoryWithMatchExtraFiles(t *testing.T) {
 	file1 := WithFile("file1", "same in both")
 	dir := NewDir(t, t.Name(),


### PR DESCRIPTION
Contrary to golden files, `eqFile` does not remove the `\r\n` before checking the equality.
This pull request fixes it and adds a test.