### PR TITLE
Fix panic and error when assert called in a defer

### DIFF
--- a/assert/result.go
+++ b/assert/result.go
@@ -70,7 +70,6 @@ func filterPrintableExpr(args []ast.Expr) []ast.Expr {
 			result[i] = starExpr.X
 			continue
 		}
-		result[i] = nil
 	}
 	return result
 }

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -33,7 +33,9 @@ job=watch:
   interactive: true
   command: |
       filewatcher -x vendor gotestsum -- -test.timeout 10s
-  env: ['GOTESTSUM_FORMAT=short-verbose']
+  env:
+    - 'GOTESTSUM_FORMAT=short-verbose'
+    - 'GOTESTTOOLS_DEBUG={env.GOTESTTOOLS_DEBUG:}'
 
 job=test-unit:
   use: builder

--- a/internal/source/defers.go
+++ b/internal/source/defers.go
@@ -1,0 +1,53 @@
+package source
+
+import (
+	"go/ast"
+	"go/token"
+
+	"github.com/pkg/errors"
+)
+
+func scanToDeferLine(fileset *token.FileSet, node ast.Node, lineNum int) ast.Node {
+	var matchedNode ast.Node
+	ast.Inspect(node, func(node ast.Node) bool {
+		switch {
+		case node == nil || matchedNode != nil:
+			return false
+		case fileset.Position(node.End()).Line == lineNum:
+			if funcLit, ok := node.(*ast.FuncLit); ok {
+				matchedNode = funcLit
+				return false
+			}
+		}
+		return true
+	})
+	debug("defer line node: %s", debugFormatNode{matchedNode})
+	return matchedNode
+}
+
+func guessDefer(node ast.Node) (ast.Node, error) {
+	defers := collectDefers(node)
+	switch len(defers) {
+	case 0:
+		return nil, errors.New("failed to expression in defer")
+	case 1:
+		return defers[0].Call, nil
+	default:
+		return nil, errors.Errorf(
+			"ambiguous call expression: multiple (%d) defers in call block",
+			len(defers))
+	}
+}
+
+func collectDefers(node ast.Node) []*ast.DeferStmt {
+	var defers []*ast.DeferStmt
+	ast.Inspect(node, func(node ast.Node) bool {
+		if d, ok := node.(*ast.DeferStmt); ok {
+			defers = append(defers, d)
+			debug("defer: %s", debugFormatNode{d})
+			return false
+		}
+		return true
+	})
+	return defers
+}

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -24,109 +24,10 @@ func FormattedCallExprArg(stackIndex int, argPos int) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if argPos >= len(args) {
+		return "", errors.New("no arg")
+	}
 	return FormatNode(args[argPos])
-}
-
-func getNodeAtLine(filename string, lineNum int) (ast.Node, error) {
-	fileset := token.NewFileSet()
-	astFile, err := parser.ParseFile(fileset, filename, nil, parser.AllErrors)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse source file: %s", filename)
-	}
-
-	node := scanToLine(fileset, astFile, lineNum)
-	if node == nil {
-		return nil, errors.Errorf(
-			"failed to find an expression on line %d in %s", lineNum, filename)
-	}
-	return node, nil
-}
-
-func scanToLine(fileset *token.FileSet, node ast.Node, lineNum int) ast.Node {
-	v := &scanToLineVisitor{lineNum: lineNum, fileset: fileset}
-	ast.Walk(v, node)
-	return v.matchedNode
-}
-
-type scanToLineVisitor struct {
-	lineNum     int
-	matchedNode ast.Node
-	fileset     *token.FileSet
-}
-
-func (v *scanToLineVisitor) Visit(node ast.Node) ast.Visitor {
-	if node == nil || v.matchedNode != nil {
-		return nil
-	}
-	if v.nodePosition(node).Line == v.lineNum {
-		v.matchedNode = node
-		return nil
-	}
-	return v
-}
-
-// In golang 1.9 the line number changed from being the line where the statement
-// ended to the line where the statement began.
-func (v *scanToLineVisitor) nodePosition(node ast.Node) token.Position {
-	if goVersionBefore19 {
-		return v.fileset.Position(node.End())
-	}
-	return v.fileset.Position(node.Pos())
-}
-
-var goVersionBefore19 = isGOVersionBefore19()
-
-func isGOVersionBefore19() bool {
-	version := runtime.Version()
-	// not a release version
-	if !strings.HasPrefix(version, "go") {
-		return false
-	}
-	version = strings.TrimPrefix(version, "go")
-	parts := strings.Split(version, ".")
-	if len(parts) < 2 {
-		return false
-	}
-	minor, err := strconv.ParseInt(parts[1], 10, 32)
-	return err == nil && parts[0] == "1" && minor < 9
-}
-
-func getCallExprArgs(node ast.Node) ([]ast.Expr, error) {
-	visitor := &callExprVisitor{}
-	ast.Walk(visitor, node)
-	if visitor.expr == nil {
-		return nil, errors.New("failed to find call expression")
-	}
-	debug("using (%T): %s", visitor.expr, debugFormatNode{visitor.expr})
-	return visitor.expr.Args, nil
-}
-
-type callExprVisitor struct {
-	expr *ast.CallExpr
-}
-
-func (v *callExprVisitor) Visit(node ast.Node) ast.Visitor {
-	if v.expr != nil || node == nil {
-		return nil
-	}
-	debug("visit (%T): %s", node, debugFormatNode{node})
-
-	switch typed := node.(type) {
-	case *ast.DeferStmt:
-		ast.Walk(v, typed.Call.Fun)
-		return nil
-	case *ast.CallExpr:
-		v.expr = typed
-		return nil
-	}
-	return v
-}
-
-// FormatNode using go/format.Node and return the result as a string
-func FormatNode(node ast.Node) (string, error) {
-	buf := new(bytes.Buffer)
-	err := format.Node(buf, token.NewFileSet(), node)
-	return buf.String(), err
 }
 
 // CallExprArgs returns the ast.Expr slice for the args of an ast.CallExpr at
@@ -145,6 +46,98 @@ func CallExprArgs(stackIndex int) ([]ast.Expr, error) {
 	debug("found node (%T): %s", node, debugFormatNode{node})
 
 	return getCallExprArgs(node)
+}
+
+func getNodeAtLine(filename string, lineNum int) (ast.Node, error) {
+	fileset := token.NewFileSet()
+	astFile, err := parser.ParseFile(fileset, filename, nil, parser.AllErrors)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse source file: %s", filename)
+	}
+
+	node := scanToLine(fileset, astFile, lineNum)
+	if node == nil {
+		return nil, errors.Errorf(
+			"failed to find an expression on line %d in %s", lineNum, filename)
+	}
+	return node, nil
+}
+
+func scanToLine(fileset *token.FileSet, node ast.Node, lineNum int) ast.Node {
+	var matchedNode ast.Node
+	ast.Inspect(node, func(node ast.Node) bool {
+		if node == nil || matchedNode != nil {
+			return false
+		}
+		if nodePosition(fileset, node).Line == lineNum {
+			matchedNode = node
+			return false
+		}
+		return true
+	})
+	return matchedNode
+}
+
+// In golang 1.9 the line number changed from being the line where the statement
+// ended to the line where the statement began.
+func nodePosition(fileset *token.FileSet, node ast.Node) token.Position {
+	if goVersionBefore19 {
+		return fileset.Position(node.End())
+	}
+	return fileset.Position(node.Pos())
+}
+
+var goVersionBefore19 = func() bool {
+	version := runtime.Version()
+	// not a release version
+	if !strings.HasPrefix(version, "go") {
+		return false
+	}
+	version = strings.TrimPrefix(version, "go")
+	parts := strings.Split(version, ".")
+	if len(parts) < 2 {
+		return false
+	}
+	minor, err := strconv.ParseInt(parts[1], 10, 32)
+	return err == nil && parts[0] == "1" && minor < 9
+}()
+
+func getCallExprArgs(node ast.Node) ([]ast.Expr, error) {
+	visitor := &callExprVisitor{}
+	ast.Walk(visitor, node)
+	if visitor.expr == nil {
+		return nil, errors.New("failed to find call expression")
+	}
+	debug("usaing (%T): %s", visitor.expr, debugFormatNode{visitor.expr})
+	return visitor.expr.Args, nil
+}
+
+type callExprVisitor struct {
+	expr *ast.CallExpr
+}
+
+func (v *callExprVisitor) Visit(node ast.Node) ast.Visitor {
+	if v.expr != nil || node == nil {
+		return nil
+	}
+	debug("visit (%T): %s", node, debugFormatNode{node})
+
+	switch typed := node.(type) {
+	case *ast.CallExpr:
+		v.expr = typed
+		return nil
+	case *ast.DeferStmt:
+		ast.Walk(v, typed.Call.Fun)
+		return nil
+	}
+	return v
+}
+
+// FormatNode using go/format.Node and return the result as a string
+func FormatNode(node ast.Node) (string, error) {
+	buf := new(bytes.Buffer)
+	err := format.Node(buf, token.NewFileSet(), node)
+	return buf.String(), err
 }
 
 var debugEnabled = os.Getenv("GOTESTTOOLS_DEBUG") != ""

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -25,7 +25,7 @@ func FormattedCallExprArg(stackIndex int, argPos int) (string, error) {
 		return "", err
 	}
 	if argPos >= len(args) {
-		return "", errors.New("no arg")
+		return "", errors.New("failed to find expression")
 	}
 	return FormatNode(args[argPos])
 }

--- a/internal/source/source_test.go
+++ b/internal/source/source_test.go
@@ -45,7 +45,6 @@ func shim(_, _, _ string) (string, error) {
 func TestFormattedCallExprArg_InDefer(t *testing.T) {
 	cap := &capture{}
 	func() {
-		fmt.Println()
 		defer cap.shim("first", "second")
 	}()
 
@@ -72,4 +71,15 @@ func TestFormattedCallExprArg_InAnonymousDefer(t *testing.T) {
 
 	assert.NilError(t, cap.err)
 	assert.Equal(t, cap.value, `"second"`)
+}
+
+func TestFormattedCallExprArg_InDeferMultipleDefers(t *testing.T) {
+	cap := &capture{}
+	func() {
+		fmt.Println()
+		defer fmt.Println()
+		defer cap.shim("first", "second")
+	}()
+
+	assert.ErrorContains(t, cap.err, "ambiguous call expression")
 }

--- a/internal/source/source_test.go
+++ b/internal/source/source_test.go
@@ -43,12 +43,10 @@ func shim(_, _, _ string) (string, error) {
 }
 
 func TestFormattedCallExprArg_InDefer(t *testing.T) {
-	t.Skip("defer reports end of function block as line number")
 	cap := &capture{}
 	func() {
 		fmt.Println()
-		defer fmt.Println()
-		defer cap.shim("first", "second\n")
+		defer cap.shim("first", "second")
 	}()
 
 	assert.NilError(t, cap.err)

--- a/internal/source/source_test.go
+++ b/internal/source/source_test.go
@@ -5,10 +5,13 @@ package source_test
 
 import (
 	"fmt"
+	"runtime"
+	"strings"
 	"testing"
 
 	"gotest.tools/assert"
 	"gotest.tools/internal/source"
+	"gotest.tools/skip"
 )
 
 func TestFormattedCallExprArg_SingleLine(t *testing.T) {
@@ -43,6 +46,7 @@ func shim(_, _, _ string) (string, error) {
 }
 
 func TestFormattedCallExprArg_InDefer(t *testing.T) {
+	skip.If(t, isGoVersion18)
 	cap := &capture{}
 	func() {
 		defer cap.shim("first", "second")
@@ -50,6 +54,10 @@ func TestFormattedCallExprArg_InDefer(t *testing.T) {
 
 	assert.NilError(t, cap.err)
 	assert.Equal(t, cap.value, `"second"`)
+}
+
+func isGoVersion18() bool {
+	return strings.HasPrefix(runtime.Version(), "go1.8.")
 }
 
 type capture struct {
@@ -74,6 +82,7 @@ func TestFormattedCallExprArg_InAnonymousDefer(t *testing.T) {
 }
 
 func TestFormattedCallExprArg_InDeferMultipleDefers(t *testing.T) {
+	skip.If(t, isGoVersion18)
 	cap := &capture{}
 	func() {
 		fmt.Println()


### PR DESCRIPTION
Fixes #111

The panic when assert is called from an anonymous function in a defer is fixed by adding `case *ast.DeferStmt` to `callExprVisitor`. These expressions can be found unambiguously so they should work the same as other expressions. Also added a check that the index is within bounds so that the panic can't happen again (even if there are other cases that aren't expected).

The error caused by deferring an assert directly (without a function wrapping the assert) unfortunately seems to cause a problem. The line number returned by `runtime.Caller` ends up being the closing brace of the function which contains the defer, not the line where the defer was setup. This means that we've lost information about where the call is actually coming from. If there is a single defer we can make a reasonable assumption that is the assert we're looking for. If there is more than one defer than an error will be raised indicating that we can't find the call expression.

It might be possible to use the function name to match to the correct defer but I'm not sure how reliable that is.

A couple of the new tests are skipped on go1.8 because go1.8 always reported the end line for expressions. This means that we don't have a good way of distinguishing defer expressions from other expressions. Since go 1.11 is going to be released soon, and go1.8 is already 2 versions old, I'm not going to worry about that case.

