### PR TITLE
Fix NewFile/NewDir when called with t.Name (or path any separator)

### DIFF
--- a/fs/file.go
+++ b/fs/file.go
@@ -7,6 +7,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 
 	"gotest.tools/assert"
 	"gotest.tools/x/subtest"
@@ -40,7 +42,7 @@ func NewFile(t assert.TestingT, prefix string, ops ...PathOp) *File {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
 	}
-	tempfile, err := ioutil.TempFile("", prefix+"-")
+	tempfile, err := ioutil.TempFile("", cleanPrefix(prefix)+"-")
 	assert.NilError(t, err)
 	file := &File{path: tempfile.Name()}
 	assert.NilError(t, tempfile.Close())
@@ -52,6 +54,14 @@ func NewFile(t assert.TestingT, prefix string, ops ...PathOp) *File {
 		tc.AddCleanup(file.Remove)
 	}
 	return file
+}
+
+func cleanPrefix(prefix string) string {
+	// windows requires both / and \ are replaced
+	if runtime.GOOS == "windows" {
+		prefix = strings.Replace(prefix, string(os.PathSeparator), "-", -1)
+	}
+	return strings.Replace(prefix, "/", "-", -1)
 }
 
 // Path returns the full path to the file
@@ -76,7 +86,7 @@ func NewDir(t assert.TestingT, prefix string, ops ...PathOp) *Dir {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
 	}
-	path, err := ioutil.TempDir("", prefix+"-")
+	path, err := ioutil.TempDir("", cleanPrefix(prefix)+"-")
 	assert.NilError(t, err)
 	dir := &Dir{path: path}
 

--- a/fs/file_test.go
+++ b/fs/file_test.go
@@ -38,3 +38,26 @@ func TestNewDirWithOpsAndManifestEqual(t *testing.T) {
 	)
 	assert.Assert(t, fs.Equal(dir.Path(), fs.Expected(t, manifestOps...)))
 }
+
+func TestNewFile(t *testing.T) {
+	t.Run("with test name", func(t *testing.T) {
+		tmpFile := fs.NewFile(t, t.Name())
+		_, err := os.Stat(tmpFile.Path())
+		assert.NilError(t, err)
+
+		tmpFile.Remove()
+		_, err = os.Stat(tmpFile.Path())
+		assert.ErrorType(t, err, os.IsNotExist)
+	})
+
+	t.Run(`with \ in name`, func(t *testing.T) {
+		tmpFile := fs.NewFile(t, `foo\thing`)
+		_, err := os.Stat(tmpFile.Path())
+		assert.NilError(t, err)
+
+		tmpFile.Remove()
+		_, err = os.Stat(tmpFile.Path())
+		assert.ErrorType(t, err, os.IsNotExist)
+	})
+
+}


### PR DESCRIPTION
Closes #99