### PR TITLE
Add some CmdOps to make `RunCmd` more useful

### DIFF
--- a/icmd/ops.go
+++ b/icmd/ops.go
@@ -1,4 +1,38 @@
 package icmd
 
+import (
+	"io"
+	"time"
+)
+
 // CmdOp is an operation which modified a Cmd structure used to execute commands
 type CmdOp func(*Cmd)
+
+// WithTimeout sets the timeout duration of the command
+func WithTimeout(timeout time.Duration) CmdOp {
+	return func(c *Cmd) {
+		c.Timeout = timeout
+	}
+}
+
+// WithEnv sets the environment variable of the command.
+// Each arguments are in the form of KEY=VALUE
+func WithEnv(env ...string) CmdOp {
+	return func(c *Cmd) {
+		c.Env = env
+	}
+}
+
+// Dir sets the working directory of the command
+func Dir(path string) CmdOp {
+	return func(c *Cmd) {
+		c.Dir = path
+	}
+}
+
+// WithStdin sets the standard input of the command to the specified reader
+func WithStdin(r io.Reader) CmdOp {
+	return func(c *Cmd) {
+		c.Stdin = r
+	}
+}


### PR DESCRIPTION
Adding WithTimeout, WithEnv, Dir and WithStdin as I think those are the most used/required.

This way we can start using `icmd.RunCmd` with those operators instead of always creating `icmd.Cmd` manually :angel: 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>