### PR TITLE
Add MatchExtraFilesGlob PathOp

### DIFF
--- a/fs/manifest.go
+++ b/fs/manifest.go
@@ -45,6 +45,7 @@ func (f *symlink) Type() string {
 type directory struct {
 	resource
 	items map[string]dirEntry
+	globs []string
 }
 
 func (f *directory) Type() string {

--- a/fs/manifest.go
+++ b/fs/manifest.go
@@ -44,8 +44,8 @@ func (f *symlink) Type() string {
 
 type directory struct {
 	resource
-	items map[string]dirEntry
-	globs []string
+	items         map[string]dirEntry
+	filepathGlobs map[string]*filePath
 }
 
 func (f *directory) Type() string {
@@ -97,8 +97,9 @@ func newDirectory(path string, info os.FileInfo) (*directory, error) {
 	}
 
 	return &directory{
-		resource: newResourceFromInfo(info),
-		items:    items,
+		resource:      newResourceFromInfo(info),
+		items:         items,
+		filepathGlobs: make(map[string]*filePath),
 	}, nil
 }
 

--- a/fs/manifest_test.go
+++ b/fs/manifest_test.go
@@ -54,6 +54,7 @@ func TestManifestFromDir(t *testing.T) {
 							content:  readCloser("content k"),
 						},
 					},
+					filepathGlobs: map[string]*filePath{},
 				},
 				"f": &symlink{
 					resource: newResource(defaultSymlinkMode),
@@ -64,6 +65,7 @@ func TestManifestFromDir(t *testing.T) {
 					content:  readCloser("content x"),
 				},
 			},
+			filepathGlobs: map[string]*filePath{},
 		},
 	}
 	actual := ManifestFromDir(t, srcDir.Path())

--- a/fs/path.go
+++ b/fs/path.go
@@ -71,6 +71,11 @@ func (p *directoryPath) AddDirectory(path string, ops ...PathOp) error {
 	return applyPathOps(exp, ops)
 }
 
+func (p *directoryPath) AddGlob(glob string, ops ...PathOp) error {
+	p.directory.globs = append(p.directory.globs, glob)
+	return nil
+}
+
 // Expected returns a Manifest with a directory structured created by ops. The
 // PathOp operations are applied to the manifest as expectations of the
 // filesystem structure and properties.
@@ -162,6 +167,17 @@ func MatchFileContent(f func([]byte) CompareResult) PathOp {
 	return func(path Path) error {
 		if m, ok := path.(*filePath); ok {
 			m.file.compareContentFunc = f
+		}
+		return nil
+	}
+}
+
+// MatchExtraFilesGlob is a PathOp that updates a Manifest to allow extra files in a directory which
+// match the file glob pattern, and with properties that match all ops.
+func MatchExtraFilesGlob(glob string, ops ...PathOp) PathOp {
+	return func(path Path) error {
+		if m, ok := path.(*directoryPath); ok {
+			m.AddGlob(glob, ops...)
 		}
 		return nil
 	}

--- a/fs/path.go
+++ b/fs/path.go
@@ -175,7 +175,7 @@ func MatchFileContent(f func([]byte) CompareResult) PathOp {
 	}
 }
 
-// MatchFilesWithGlob is a PathOp that updates a Manifest to mathc files using
+// MatchFilesWithGlob is a PathOp that updates a Manifest to match files using
 // glob pattern, and check them using the ops.
 func MatchFilesWithGlob(glob string, ops ...PathOp) PathOp {
 	return func(path Path) error {

--- a/fs/report_test.go
+++ b/fs/report_test.go
@@ -8,6 +8,7 @@ import (
 
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
+	"gotest.tools/skip"
 )
 
 func TestEqualMissingRoot(t *testing.T) {
@@ -223,22 +224,19 @@ func TestMatchExtraFilesGlob(t *testing.T) {
 	})
 
 	t.Run("matching globs with wrong mode", func(t *testing.T) {
+		skip.If(t, runtime.GOOS == "windows", "expect mode does not match on windows")
 		manifest := Expected(t,
 			MatchFilesWithGlob("*.go", MatchAnyFileMode, MatchAnyFileContent),
 			MatchFilesWithGlob("*.yml", MatchAnyFileContent, WithMode(0700)))
 
 		result := Equal(dir.Path(), manifest)()
 
-		if runtime.GOOS == "windows" {
-			assert.Assert(t, result.Success())
-		} else {
-			assert.Assert(t, !result.Success())
-			expected := fmtExpected(`directory %s does not match expected:
+		assert.Assert(t, !result.Success())
+		expected := fmtExpected(`directory %s does not match expected:
 conf.yml
   mode: expected -rwx------ got -rw-------
 `, dir.Path())
-			assert.Equal(t, result.(cmpFailure).FailureMessage(), expected)
-		}
+		assert.Equal(t, result.(cmpFailure).FailureMessage(), expected)
 	})
 
 	t.Run("matching partial glob", func(t *testing.T) {


### PR DESCRIPTION
This PR adds `MatchExtraFilesGlob` PathOp. 
As discuss in #133, this is a starting point.

@dnephin regarding the function

     func MatchExtraFilesGlob(glob string, ops ...PathOp) PathOp 

What should I do with the `ops` parameter? should I apply it to the `directoryPath` in the `AddGlob` function (as it is done for other `directoryPath` functions)?

Signed-off-by: glefloch <glfloch@gmail.com>