### PR TITLE
Release v3 - with full go module support

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -70,9 +70,9 @@ import (
 	"go/token"
 
 	gocmp "github.com/google/go-cmp/cmp"
-	"gotest.tools/assert/cmp"
-	"gotest.tools/internal/format"
-	"gotest.tools/internal/source"
+	"gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/internal/format"
+	"gotest.tools/v3/internal/source"
 )
 
 // BoolOrComparison can be a bool, or cmp.Comparison. See Assert() for usage.

--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	gocmp "github.com/google/go-cmp/cmp"
-	"gotest.tools/assert/cmp"
+	"gotest.tools/v3/assert/cmp"
 )
 
 type fakeTestingT struct {

--- a/assert/cmd/gty-migrate-from-testify/call_test.go
+++ b/assert/cmd/gty-migrate-from-testify/call_test.go
@@ -5,7 +5,7 @@ import (
 	"go/token"
 	"testing"
 
-	"gotest.tools/assert"
+	"gotest.tools/v3/assert"
 )
 
 func TestCall_String(t *testing.T) {

--- a/assert/cmd/gty-migrate-from-testify/main_test.go
+++ b/assert/cmd/gty-migrate-from-testify/main_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"gotest.tools/assert"
-	"gotest.tools/env"
-	"gotest.tools/fs"
-	"gotest.tools/golden"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/env"
+	"gotest.tools/v3/fs"
+	"gotest.tools/v3/golden"
 )
 
 func TestRun(t *testing.T) {

--- a/assert/cmd/gty-migrate-from-testify/migrate_test.go
+++ b/assert/cmd/gty-migrate-from-testify/migrate_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"golang.org/x/tools/go/loader"
-	"gotest.tools/assert"
-	"gotest.tools/assert/cmp"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
 )
 
 func TestMigrateFileReplacesTestingT(t *testing.T) {

--- a/assert/cmp/compare.go
+++ b/assert/cmp/compare.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
-	"gotest.tools/internal/format"
+	"gotest.tools/v3/internal/format"
 )
 
 // Comparison is a function which compares values and returns ResultSuccess if

--- a/assert/cmp/compare_test.go
+++ b/assert/cmp/compare_test.go
@@ -313,7 +313,7 @@ func TestError(t *testing.T) {
 	assertFailureHasPrefix(t, result,
 		`expected error "the error message", got "wrapped: other"
 other
-gotest.tools/assert/cmp.TestError`)
+gotest.tools`)
 
 	msg := "the message"
 	result = Error(errors.New(msg), msg)()

--- a/assert/cmp/result.go
+++ b/assert/cmp/result.go
@@ -6,7 +6,7 @@ import (
 	"go/ast"
 	"text/template"
 
-	"gotest.tools/internal/source"
+	"gotest.tools/v3/internal/source"
 )
 
 // A Result of a Comparison.

--- a/assert/example_test.go
+++ b/assert/example_test.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 	"testing"
 
-	"gotest.tools/assert"
-	"gotest.tools/assert/cmp"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
 )
 
 var t = &testing.T{}

--- a/assert/opt/opt_test.go
+++ b/assert/opt/opt_test.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	gocmp "github.com/google/go-cmp/cmp"
-	"gotest.tools/assert"
-	"gotest.tools/internal/source"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/internal/source"
 )
 
 func TestDurationWithThreshold(t *testing.T) {

--- a/assert/result.go
+++ b/assert/result.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"go/ast"
 
-	"gotest.tools/assert/cmp"
-	"gotest.tools/internal/format"
-	"gotest.tools/internal/source"
+	"gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/internal/format"
+	"gotest.tools/v3/internal/source"
 )
 
 func runComparison(

--- a/env/env.go
+++ b/env/env.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strings"
 
-	"gotest.tools/assert"
-	"gotest.tools/x/subtest"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/x/subtest"
 )
 
 type helperT interface {

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -6,9 +6,9 @@ import (
 	"sort"
 	"testing"
 
-	"gotest.tools/assert"
-	"gotest.tools/fs"
-	"gotest.tools/skip"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+	"gotest.tools/v3/skip"
 )
 
 func TestPatchFromUnset(t *testing.T) {

--- a/fs/example_test.go
+++ b/fs/example_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
-	"gotest.tools/assert"
-	"gotest.tools/assert/cmp"
-	"gotest.tools/fs"
-	"gotest.tools/golden"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/fs"
+	"gotest.tools/v3/golden"
 )
 
 var t = &testing.T{}

--- a/fs/file.go
+++ b/fs/file.go
@@ -10,8 +10,8 @@ import (
 	"runtime"
 	"strings"
 
-	"gotest.tools/assert"
-	"gotest.tools/x/subtest"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/x/subtest"
 )
 
 // Path objects return their filesystem path. Path may be implemented by a

--- a/fs/file_test.go
+++ b/fs/file_test.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"testing"
 
-	"gotest.tools/assert"
-	"gotest.tools/fs"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
 )
 
 func TestNewDirWithOpsAndManifestEqual(t *testing.T) {

--- a/fs/manifest.go
+++ b/fs/manifest.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
-	"gotest.tools/assert"
+	"gotest.tools/v3/assert"
 )
 
 // Manifest stores the expected structure and properties of files and directories

--- a/fs/manifest_test.go
+++ b/fs/manifest_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"gotest.tools/assert"
+	"gotest.tools/v3/assert"
 )
 
 func TestManifestFromDir(t *testing.T) {

--- a/fs/ops.go
+++ b/fs/ops.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"gotest.tools/assert"
+	"gotest.tools/v3/assert"
 )
 
 const defaultFileMode = 0644

--- a/fs/ops_test.go
+++ b/fs/ops_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"gotest.tools/assert"
-	"gotest.tools/fs"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
 )
 
 func TestFromDir(t *testing.T) {

--- a/fs/path.go
+++ b/fs/path.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"gotest.tools/assert"
+	"gotest.tools/v3/assert"
 )
 
 // resourcePath is an adaptor for resources so they can be used as a Path

--- a/fs/report.go
+++ b/fs/report.go
@@ -10,8 +10,8 @@ import (
 	"sort"
 	"strings"
 
-	"gotest.tools/assert/cmp"
-	"gotest.tools/internal/format"
+	"gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/internal/format"
 )
 
 // Equal compares a directory to the expected structured described by a manifest

--- a/fs/report_test.go
+++ b/fs/report_test.go
@@ -6,9 +6,9 @@ import (
 	"runtime"
 	"testing"
 
-	"gotest.tools/assert"
-	is "gotest.tools/assert/cmp"
-	"gotest.tools/skip"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/skip"
 )
 
 func TestEqualMissingRoot(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gotest.tools
+module gotest.tools/v3
 
 require (
 	github.com/google/go-cmp v0.3.0

--- a/golden/example_test.go
+++ b/golden/example_test.go
@@ -3,8 +3,8 @@ package golden_test
 import (
 	"testing"
 
-	"gotest.tools/assert"
-	"gotest.tools/golden"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/golden"
 )
 
 var t = &testing.T{}

--- a/golden/golden.go
+++ b/golden/golden.go
@@ -12,9 +12,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"gotest.tools/assert"
-	"gotest.tools/assert/cmp"
-	"gotest.tools/internal/format"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/internal/format"
 )
 
 var flagUpdate = flag.Bool("test.update-golden", false, "update golden file")

--- a/golden/golden_test.go
+++ b/golden/golden_test.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"gotest.tools/assert"
-	"gotest.tools/assert/cmp"
-	"gotest.tools/fs"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/fs"
 )
 
 type fakeT struct {

--- a/icmd/command.go
+++ b/icmd/command.go
@@ -12,8 +12,8 @@ import (
 	"sync"
 	"time"
 
-	"gotest.tools/assert"
-	"gotest.tools/assert/cmp"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
 )
 
 type helperT interface {

--- a/icmd/command_test.go
+++ b/icmd/command_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"gotest.tools/assert"
-	"gotest.tools/fs"
-	"gotest.tools/golden"
-	"gotest.tools/internal/maint"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+	"gotest.tools/v3/golden"
+	"gotest.tools/v3/internal/maint"
 )
 
 var (

--- a/icmd/example_test.go
+++ b/icmd/example_test.go
@@ -3,7 +3,7 @@ package icmd_test
 import (
 	"testing"
 
-	"gotest.tools/icmd"
+	"gotest.tools/v3/icmd"
 )
 
 var t = &testing.T{}

--- a/internal/format/diff.go
+++ b/internal/format/diff.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"unicode"
 
-	"gotest.tools/internal/difflib"
+	"gotest.tools/v3/internal/difflib"
 )
 
 const (

--- a/internal/format/diff_test.go
+++ b/internal/format/diff_test.go
@@ -3,9 +3,9 @@ package format_test
 import (
 	"testing"
 
-	"gotest.tools/assert"
-	"gotest.tools/golden"
-	"gotest.tools/internal/format"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/golden"
+	"gotest.tools/v3/internal/format"
 )
 
 func TestUnifiedDiff(t *testing.T) {

--- a/internal/format/format_test.go
+++ b/internal/format/format_test.go
@@ -3,8 +3,8 @@ package format_test
 import (
 	"testing"
 
-	"gotest.tools/assert"
-	"gotest.tools/internal/format"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/internal/format"
 )
 
 func TestMessage(t *testing.T) {

--- a/internal/source/source_test.go
+++ b/internal/source/source_test.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"testing"
 
-	"gotest.tools/assert"
-	"gotest.tools/internal/source"
-	"gotest.tools/skip"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/internal/source"
+	"gotest.tools/v3/skip"
 )
 
 func TestFormattedCallExprArg_SingleLine(t *testing.T) {

--- a/poll/check_test.go
+++ b/poll/check_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"gotest.tools/assert"
+	"gotest.tools/v3/assert"
 )
 
 func TestWaitOnFile(t *testing.T) {

--- a/poll/example_test.go
+++ b/poll/example_test.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"gotest.tools/poll"
+	"gotest.tools/v3/poll"
 )
 
 var t poll.TestingT

--- a/poll/poll_test.go
+++ b/poll/poll_test.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"gotest.tools/assert"
-	"gotest.tools/assert/cmp"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
 )
 
 type fakeT struct {

--- a/skip/example_test.go
+++ b/skip/example_test.go
@@ -3,7 +3,7 @@ package skip_test
 import (
 	"testing"
 
-	"gotest.tools/skip"
+	"gotest.tools/v3/skip"
 )
 
 var apiVersion = ""

--- a/skip/skip.go
+++ b/skip/skip.go
@@ -10,8 +10,8 @@ import (
 	"runtime"
 	"strings"
 
-	"gotest.tools/internal/format"
-	"gotest.tools/internal/source"
+	"gotest.tools/v3/internal/format"
+	"gotest.tools/v3/internal/source"
 )
 
 type skipT interface {

--- a/skip/skip_test.go
+++ b/skip/skip_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	"gotest.tools/assert"
-	"gotest.tools/assert/cmp"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
 )
 
 type fakeSkipT struct {

--- a/x/subtest/context_test.go
+++ b/x/subtest/context_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"gotest.tools/assert"
+	"gotest.tools/v3/assert"
 )
 
 func TestTestcase_Run_CallsCleanup(t *testing.T) {

--- a/x/subtest/example_test.go
+++ b/x/subtest/example_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"gotest.tools/assert"
-	"gotest.tools/x/subtest"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/x/subtest"
 )
 
 var t = &testing.T{}


### PR DESCRIPTION
To properly support go modules we need a new import path. Following https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher the correct way to do that seems to be to release a new major version.

According to those docs this will be supported by the latest patch release of go1.9 and go1.10 as well.

Closes #156 