### PR TITLE
Remove unnecessary normalize

### DIFF
--- a/assert/cmp/result.go
+++ b/assert/cmp/result.go
@@ -52,13 +52,12 @@ func ResultFromError(err error) Result {
 }
 
 type templatedResult struct {
-	success  bool
 	template string
 	data     map[string]interface{}
 }
 
 func (r templatedResult) Success() bool {
-	return r.success
+	return false
 }
 
 func (r templatedResult) FailureMessage(args []ast.Expr) string {

--- a/golden/golden.go
+++ b/golden/golden.go
@@ -54,14 +54,12 @@ func Path(filename string) string {
 	return filepath.Join("testdata", filename)
 }
 
-func update(filename string, actual []byte, normalize normalize) error {
+func update(filename string, actual []byte) error {
 	if *flagUpdate {
-		return ioutil.WriteFile(Path(filename), normalize(actual), 0644)
+		return ioutil.WriteFile(Path(filename), actual, 0644)
 	}
 	return nil
 }
-
-type normalize func([]byte) []byte
 
 func removeCarriageReturn(in []byte) []byte {
 	return bytes.Replace(in, []byte("\r\n"), []byte("\n"), -1)
@@ -97,7 +95,7 @@ func Assert(t assert.TestingT, actual string, filename string, msgAndArgs ...int
 func String(actual string, filename string) cmp.Comparison {
 	return func() cmp.Result {
 		actualBytes := removeCarriageReturn([]byte(actual))
-		result, expected := compare(actualBytes, filename, removeCarriageReturn)
+		result, expected := compare(actualBytes, filename)
 		if result != nil {
 			return result
 		}
@@ -143,7 +141,7 @@ func AssertBytes(
 // to the golden file.
 func Bytes(actual []byte, filename string) cmp.Comparison {
 	return func() cmp.Result {
-		result, expected := compare(actual, filename, exactBytes)
+		result, expected := compare(actual, filename)
 		if result != nil {
 			return result
 		}
@@ -152,8 +150,8 @@ func Bytes(actual []byte, filename string) cmp.Comparison {
 	}
 }
 
-func compare(actual []byte, filename string, normalize normalize) (cmp.Result, []byte) {
-	if err := update(filename, actual, normalize); err != nil {
+func compare(actual []byte, filename string) (cmp.Result, []byte) {
+	if err := update(filename, actual); err != nil {
 		return cmp.ResultFromError(err), nil
 	}
 	expected, err := ioutil.ReadFile(Path(filename))

--- a/golden/golden.go
+++ b/golden/golden.go
@@ -65,10 +65,6 @@ func removeCarriageReturn(in []byte) []byte {
 	return bytes.Replace(in, []byte("\r\n"), []byte("\n"), -1)
 }
 
-func exactBytes(in []byte) []byte {
-	return in
-}
-
 // Assert compares actual to the expected value in the golden file.
 //
 // Running `go test pkgname -test.update-golden` will write the value of actual

--- a/golden/golden_test.go
+++ b/golden/golden_test.go
@@ -117,7 +117,7 @@ func TestGoldenAssert(t *testing.T) {
 	assert.Assert(t, !fakeT.Failed)
 }
 
-func TestGoldenAssertWithCarriageReturnInActual(t *testing.T) {
+func TestAssert_WithCarriageReturnInActual(t *testing.T) {
 	filename, clean := setupGoldenFile(t, "a\rfoo\nbar\n")
 	defer clean()
 
@@ -125,6 +125,24 @@ func TestGoldenAssertWithCarriageReturnInActual(t *testing.T) {
 
 	Assert(fakeT, "a\rfoo\r\nbar\r\n", filename)
 	assert.Assert(t, !fakeT.Failed)
+}
+
+func TestAssert_WithCarriageReturnInActual_UpdateGolden(t *testing.T) {
+	filename, clean := setupGoldenFile(t, "")
+	defer clean()
+	unsetUpdateFlag := setUpdateFlag()
+	defer unsetUpdateFlag()
+
+	fakeT := new(fakeT)
+	Assert(fakeT, "a\rfoo\r\nbar\r\n", filename)
+	assert.Assert(t, !fakeT.Failed)
+
+	unsetUpdateFlag()
+	actual := Get(fakeT, filename)
+	assert.Equal(t, string(actual), "a\rfoo\nbar\n")
+
+	Assert(t, "a\rfoo\r\nbar\r\n", filename, "matches with carriage returns")
+	Assert(t, "a\rfoo\nbar\n", filename, "matches without carriage returns")
 }
 
 func TestGoldenAssertBytes(t *testing.T) {


### PR DESCRIPTION
We already normalize the bytes once in String, no reason to repeat the process in compare.