### PR TITLE
Appveyor go1.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  go: gotest/tools@0.0.9
+  go: gotest/tools@0.0.10
 
 workflows:
   ci:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,11 @@
 version: "{build}"
 image: Visual Studio 2017
 
-clone_folder: c:\gopath\src\gotest.tools
+clone_folder: c:\project
 
 environment:
-  PATH: c:\go110\bin;%PATH%
-  GOROOT: c:\go110
-  GOPATH: c:\gopath
-  DEPVERSION: v0.4.1
+  PATH: c:\go112\bin;%PATH%
+  GOROOT: c:\go112
 
 init:
   - git config --global core.symlinks true
@@ -19,10 +17,9 @@ install:
 deploy: false
 
 build_script:
-  - appveyor DownloadFile https://github.com/golang/dep/releases/download/%DEPVERSION%/dep-windows-amd64.exe
-  - appveyor DownloadFile https://github.com/gotestyourself/gotestsum/releases/download/v0.3.0/gotestsum_0.3.0_windows_amd64.tar.gz
-  - tar -xzf gotestsum_0.3.0_windows_amd64.tar.gz
-  - dep-windows-amd64.exe ensure
+  - appveyor DownloadFile https://github.com/gotestyourself/gotestsum/releases/download/v0.3.5/gotestsum_0.3.5_windows_amd64.tar.gz
+  - tar -xzf gotestsum_0.3.5_windows_amd64.tar.gz
+  - go mod download
 
 test_script:
   - gotestsum


### PR DESCRIPTION
go1.13 is not installed in the appveyor image yet, so using go1.12 for now. 