### PR TITLE
Handle nil structs which implement the error interface

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -68,6 +68,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
+	"reflect"
 
 	gocmp "github.com/google/go-cmp/cmp"
 	"gotest.tools/v3/assert/cmp"
@@ -118,6 +119,10 @@ func assert(
 		return true
 
 	case error:
+		// Handle nil structs which implement error as a nil error
+		if reflect.ValueOf(check).IsNil() {
+			return true
+		}
 		msg := "error is not nil: "
 		t.Log(format.WithCustomMessage(failureMessage+msg+check.Error(), msgAndArgs...))
 

--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -133,6 +133,7 @@ func TestNilErrorSuccess(t *testing.T) {
 
 	var customErr *customError
 	NilError(fakeT, customErr)
+	expectSuccess(t, fakeT)
 }
 
 func TestNilErrorFailure(t *testing.T) {


### PR DESCRIPTION
Fixes #167

The test for this case was missing an assertion for the outcome.

Nil structs will hit the 'case error` but will not look nil because
the interface has an underlying type (the struct type) which makes
it non-nil.

https://golang.org/doc/faq#nil_error