### PR TITLE
assert: Fix printing of pointer values in failure message

### DIFF
--- a/assert/cmp/compare.go
+++ b/assert/cmp/compare.go
@@ -104,10 +104,10 @@ func Equal(x, y interface{}) Comparison {
 			return multiLineDiffResult(diff)
 		}
 		return ResultFailureTemplate(`
-			{{- .Data.x}} (
+			{{- printf "%v" .Data.x}} (
 				{{- with callArg 0 }}{{ formatNode . }} {{end -}}
 				{{- printf "%T" .Data.x -}}
-			) != {{ .Data.y}} (
+			) != {{ printf "%v" .Data.y}} (
 				{{- with callArg 1 }}{{ formatNode . }} {{end -}}
 				{{- printf "%T" .Data.y -}}
 			)`,

--- a/assert/cmp/compare_test.go
+++ b/assert/cmp/compare_test.go
@@ -304,6 +304,16 @@ bbbb`
 	assertFailureTemplate(t, res, args, expected)
 }
 
+func TestEqual_PointersNotEqual(t *testing.T) {
+	x := 123
+	y := 123
+
+	res := Equal(&x, &y)()
+	args := []ast.Expr{&ast.Ident{Name: "x"}, &ast.Ident{Name: "y"}}
+	expected := fmt.Sprintf("%p (x *int) != %p (y *int)", &x, &y)
+	assertFailureTemplate(t, res, args, expected)
+}
+
 func TestError(t *testing.T) {
 	result := Error(nil, "the error message")()
 	assertFailure(t, result, "expected an error, got nil")


### PR DESCRIPTION
Fixes #173

The template seems to default to printing the referenced value, but we want the actual value of the pointer. Using `printf %v` should be correct in all cases.