### PR TITLE
Add calls to testing.TB.Cleanup() when available.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,6 +37,8 @@ issues:
       text: .
     - text: 'return value of .*Close` is not checked'
       linters: [errcheck]
+    - text: 'SA1019'
+      linters: [staticcheck]
 
 linters:
   enable-all: true
@@ -47,3 +49,4 @@ linters:
     - gosec
     - scopelint
     - maligned
+    - gocritic

--- a/fs/file.go
+++ b/fs/file.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"gotest.tools/v3/assert"
-	"gotest.tools/v3/x/subtest"
+	"gotest.tools/v3/internal/cleanup"
 )
 
 // Path objects return their filesystem path. Path may be implemented by a
@@ -36,27 +36,23 @@ type helperT interface {
 	Helper()
 }
 
-type cleanupT interface {
-	Cleanup(f func())
-}
-
 // NewFile creates a new file in a temporary directory using prefix as part of
 // the filename. The PathOps are applied to the before returning the File.
+//
+// When used with Go 1.14+ the file will be automatically removed when the test
+// ends, unless the TEST_NOCLEANUP env var is set to true.
 func NewFile(t assert.TestingT, prefix string, ops ...PathOp) *File {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
 	}
 	tempfile, err := ioutil.TempFile("", cleanPrefix(prefix)+"-")
 	assert.NilError(t, err)
+
 	file := &File{path: tempfile.Name()}
+	cleanup.Cleanup(t, file.Remove)
+
 	assert.NilError(t, tempfile.Close())
 	assert.NilError(t, applyPathOps(file, ops))
-	if tc, ok := t.(subtest.TestContext); ok {
-		tc.AddCleanup(file.Remove)
-	}
-	if ct, ok := t.(cleanupT); ok {
-		ct.Cleanup(file.Remove)
-	}
 	return file
 }
 
@@ -86,6 +82,9 @@ type Dir struct {
 
 // NewDir returns a new temporary directory using prefix as part of the directory
 // name. The PathOps are applied before returning the Dir.
+//
+// When used with Go 1.14+ the directory will be automatically removed when the test
+// ends, unless the TEST_NOCLEANUP env var is set to true.
 func NewDir(t assert.TestingT, prefix string, ops ...PathOp) *Dir {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
@@ -93,13 +92,9 @@ func NewDir(t assert.TestingT, prefix string, ops ...PathOp) *Dir {
 	path, err := ioutil.TempDir("", cleanPrefix(prefix)+"-")
 	assert.NilError(t, err)
 	dir := &Dir{path: path}
+	cleanup.Cleanup(t, dir.Remove)
+
 	assert.NilError(t, applyPathOps(dir, ops))
-	if tc, ok := t.(subtest.TestContext); ok {
-		tc.AddCleanup(dir.Remove)
-	}
-	if ct, ok := t.(cleanupT); ok {
-		ct.Cleanup(dir.Remove)
-	}
 	return dir
 }
 

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -1,0 +1,45 @@
+/*Package cleanup handles migration to and support for the Go 1.14+
+testing.TB.Cleanup() function.
+*/
+package cleanup
+
+import (
+	"os"
+	"strings"
+
+	"gotest.tools/v3/x/subtest"
+)
+
+type cleanupT interface {
+	Cleanup(f func())
+}
+
+type logT interface {
+	Log(...interface{})
+}
+
+type helperT interface {
+	Helper()
+}
+
+var noCleanup = strings.ToLower(os.Getenv("TEST_NOCLEANUP")) == "true"
+
+// Cleanup registers f as a cleanup function on t if any mechanisms are available.
+//
+// Skips registering f if TEST_NOCLEANUP is set to true.
+func Cleanup(t logT, f func()) {
+	if ht, ok := t.(helperT); ok {
+		ht.Helper()
+	}
+	if noCleanup {
+		t.Log("skipping cleanup because TEST_NOCLEANUP was enabled.")
+		return
+	}
+	if ct, ok := t.(cleanupT); ok {
+		ct.Cleanup(f)
+		return
+	}
+	if tc, ok := t.(subtest.TestContext); ok {
+		tc.AddCleanup(f)
+	}
+}

--- a/x/doc.go
+++ b/x/doc.go
@@ -1,4 +1,4 @@
-/*Package x is a namespace for other packages. Packages under x have looser
+/*Package x is a namespace for experimental packages. Packages under x have looser
 compatibility requirements. Packages in this namespace may contain backwards
 incompatible changes within the same major version.
 */

--- a/x/subtest/context.go
+++ b/x/subtest/context.go
@@ -68,6 +68,9 @@ func Run(t *testing.T, name string, subtest func(t TestContext)) bool {
 type TestContext interface {
 	testing.TB
 	// AddCleanup function which will be run when before Run returns.
+	//
+	// Deprecated: Go 1.14+ now includes a testing.TB.Cleanup(func()) which
+	// should be used instead. AddCleanup will be removed in a future release.
 	AddCleanup(f func())
 	// Ctx returns a context for the test case. Multiple calls from the same subtest
 	// will return the same context. The context is cancelled when Run


### PR DESCRIPTION
Closes #177 

Also adds TEST_NOCLEANUP to disable test cleanup for debugging, and adds to the godoc string for all functions which call `Cleanup`.