### PR TITLE
Update import alias for major version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
     executor:
       name: go/golang
       tag: 1.10-alpine
-    working_directory: /go/src/gotest.tools
+    working_directory: /go/src/gotest.tools/v3
     steps:
       - go/install: {package: git}
       - go/install-ssh

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -62,7 +62,7 @@ See http://gotest.tools/assert/cmd/gty-migrate-from-testify.
 
 
 */
-package assert // import "gotest.tools/assert"
+package assert // import "gotest.tools/v3/assert"
 
 import (
 	"fmt"

--- a/assert/cmp/compare.go
+++ b/assert/cmp/compare.go
@@ -1,5 +1,5 @@
 /*Package cmp provides Comparisons for Assert and Check*/
-package cmp // import "gotest.tools/assert/cmp"
+package cmp // import "gotest.tools/v3/assert/cmp"
 
 import (
 	"fmt"

--- a/assert/opt/opt.go
+++ b/assert/opt/opt.go
@@ -1,6 +1,6 @@
 /*Package opt provides common go-cmp.Options for use with assert.DeepEqual.
  */
-package opt // import "gotest.tools/assert/opt"
+package opt // import "gotest.tools/v3/assert/opt"
 
 import (
 	"fmt"

--- a/env/env.go
+++ b/env/env.go
@@ -1,7 +1,7 @@
 /*Package env provides functions to test code that read environment variables
 or the current working directory.
 */
-package env // import "gotest.tools/env"
+package env // import "gotest.tools/v3/env"
 
 import (
 	"os"

--- a/fs/file.go
+++ b/fs/file.go
@@ -1,7 +1,7 @@
 /*Package fs provides tools for creating temporary files, and testing the
 contents and structure of a directory.
 */
-package fs // import "gotest.tools/fs"
+package fs // import "gotest.tools/v3/fs"
 
 import (
 	"io/ioutil"

--- a/golden/golden.go
+++ b/golden/golden.go
@@ -5,7 +5,7 @@ Golden files can be automatically updated to match new values by running
 `go test pkgname -test.update-golden`. To ensure the update is correct
 compare the diff of the old expected value to the new expected value.
 */
-package golden // import "gotest.tools/golden"
+package golden // import "gotest.tools/v3/golden"
 
 import (
 	"bytes"

--- a/icmd/command.go
+++ b/icmd/command.go
@@ -1,6 +1,6 @@
 /*Package icmd executes binaries and provides convenient assertions for testing the results.
  */
-package icmd // import "gotest.tools/icmd"
+package icmd // import "gotest.tools/v3/icmd"
 
 import (
 	"bytes"

--- a/internal/difflib/difflib.go
+++ b/internal/difflib/difflib.go
@@ -4,7 +4,7 @@ Original source: https://github.com/pmezard/go-difflib
 
 This file is trimmed to only the parts used by this repository.
 */
-package difflib // import "gotest.tools/internal/difflib"
+package difflib // import "gotest.tools/v3/internal/difflib"
 
 func min(a, b int) int {
 	if a < b {

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -1,4 +1,4 @@
-package format // import "gotest.tools/internal/format"
+package format // import "gotest.tools/v3/internal/format"
 
 import "fmt"
 

--- a/internal/maint/maint.go
+++ b/internal/maint/maint.go
@@ -1,4 +1,4 @@
-package maint // import "gotest.tools/internal/maint"
+package maint // import "gotest.tools/v3/internal/maint"
 
 import (
 	"fmt"

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -1,4 +1,4 @@
-package source // import "gotest.tools/internal/source"
+package source // import "gotest.tools/v3/internal/source"
 
 import (
 	"bytes"

--- a/pkg.go
+++ b/pkg.go
@@ -1,4 +1,4 @@
 /*Package gotesttools is a collection of packages to augment `testing` and
 support common patterns.
 */
-package gotesttools // import "gotest.tools"
+package gotesttools // import "gotest.tools/v3"

--- a/poll/poll.go
+++ b/poll/poll.go
@@ -1,6 +1,6 @@
 /*Package poll provides tools for testing asynchronous code.
  */
-package poll // import "gotest.tools/poll"
+package poll // import "gotest.tools/v3/poll"
 
 import (
 	"fmt"

--- a/skip/skip.go
+++ b/skip/skip.go
@@ -1,7 +1,7 @@
 /*Package skip provides functions for skipping a test and printing the source code
 of the condition used to skip the test.
 */
-package skip // import "gotest.tools/skip"
+package skip // import "gotest.tools/v3/skip"
 
 import (
 	"fmt"

--- a/x/doc.go
+++ b/x/doc.go
@@ -2,4 +2,4 @@
 compatibility requirements. Packages in this namespace may contain backwards
 incompatible changes within the same major version.
 */
-package x // import "gotest.tools/x"
+package x // import "gotest.tools/v3/x"

--- a/x/subtest/context.go
+++ b/x/subtest/context.go
@@ -3,7 +3,7 @@ provides a testing.TB, and context.Context.
 
 This package was inspired by github.com/frankban/quicktest.
 */
-package subtest // import "gotest.tools/x/subtest"
+package subtest // import "gotest.tools/v3/x/subtest"
 
 import (
 	"context"


### PR DESCRIPTION
In order to make vendoring work with go modules we need the alias to
be as the major version, otherwise, the vendor files are in
`gotest.tools/v3/assert` but the import says `gotest.tools/assert`
which makes go fail to build without go modules.

Takes over #162
Closes #162 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>