### PR TITLE
Update godoc links to pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A collection of packages to augment `testing` and support common patterns.
 
-[![GoDoc](https://godoc.org/gotest.tools?status.svg)](http://gotest.tools)
+[![GoDoc](https://godoc.org/gotest.tools?status.svg)](https://pkg.go.dev/gotest.tools/v3/?tab=subdirectories)
 [![CircleCI](https://circleci.com/gh/gotestyourself/gotest.tools/tree/master.svg?style=shield)](https://circleci.com/gh/gotestyourself/gotest.tools/tree/master)
 [![Go Reportcard](https://goreportcard.com/badge/gotest.tools)](https://goreportcard.com/report/gotest.tools)
 
@@ -24,19 +24,19 @@ module paths pin to version `v2.3.0`.
 
 ## Packages
 
-* [assert](http://gotest.tools/assert) -
+* [assert](http://pkg.go.dev/gotest.tools/v3/assert) -
   compare values and fail the test when a comparison fails
-* [env](http://gotest.tools/env) -
+* [env](http://pkg.go.dev/gotest.tools/v3/env) -
   test code which uses environment variables
-* [fs](http://gotest.tools/fs) -
+* [fs](http://pkg.go.dev/gotest.tools/v3/fs) -
   create temporary files and compare a filesystem tree to an expected value
-* [golden](http://gotest.tools/golden) -
+* [golden](http://pkg.go.dev/gotest.tools/v3/golden) -
   compare large multi-line strings against values frozen in golden files
-* [icmd](http://gotest.tools/icmd) -
+* [icmd](http://pkg.go.dev/gotest.tools/v3/icmd) -
   execute binaries and test the output
-* [poll](http://gotest.tools/poll) -
+* [poll](http://pkg.go.dev/gotest.tools/v3/poll) -
   test asynchronous code by polling until a desired state is reached
-* [skip](http://gotest.tools/skip) -
+* [skip](http://pkg.go.dev/gotest.tools/v3/skip) -
   skip a test and print the source code of the condition used to skip the test
 
 ## Related

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -49,7 +49,7 @@ The example below shows assert used with some common types.
 
 Comparisons
 
-Package http://gotest.tools/assert/cmp provides
+Package http://pkg.go.dev/gotest.tools/v3/assert/cmp provides
 many common comparisons. Additional comparisons can be written to compare
 values in other ways. See the example Assert (CustomComparison).
 
@@ -58,7 +58,7 @@ Automated migration from testify
 gty-migrate-from-testify is a command which translates Go source code from
 testify assertions to the assertions provided by this package.
 
-See http://gotest.tools/assert/cmd/gty-migrate-from-testify.
+See http://pkg.go.dev/gotest.tools/v3/assert/cmd/gty-migrate-from-testify.
 
 
 */
@@ -222,7 +222,7 @@ func boolFailureMessage(expr ast.Expr) (string, error) {
 //   cmp.Comparison
 // Uses cmp.Result.Success() to check for success of failure.
 // The comparison is responsible for producing a helpful failure message.
-// http://gotest.tools/assert/cmp provides many common comparisons.
+// http://pkg.go.dev/gotest.tools/v3/assert/cmp provides many common comparisons.
 //   error
 // A nil value is considered success.
 // A non-nil error is a failure, err.Error() is used as the failure message.
@@ -276,7 +276,7 @@ func Equal(t TestingT, x, y interface{}, msgAndArgs ...interface{}) {
 // DeepEqual uses google/go-cmp (https://godoc.org/github.com/google/go-cmp/cmp)
 // to assert two values are equal and fails the test if they are not equal.
 //
-// Package http://gotest.tools/assert/opt provides some additional
+// Package http://pkg.go.dev/gotest.tools/v3/assert/opt provides some additional
 // commonly used Options.
 //
 // This is equivalent to Assert(t, cmp.DeepEqual(x, y)).

--- a/assert/cmp/compare.go
+++ b/assert/cmp/compare.go
@@ -21,7 +21,7 @@ type Comparison func() Result
 // and succeeds if the values are equal.
 //
 // The comparison can be customized using comparison Options.
-// Package http://gotest.tools/assert/opt provides some additional
+// Package http://pkg.go.dev/gotest.tools/v3/assert/opt provides some additional
 // commonly used Options.
 func DeepEqual(x, y interface{}, opts ...cmp.Option) Comparison {
 	return func() (result Result) {


### PR DESCRIPTION
Related to #188 

The godoc links are broken because of the /v3/ in the path, so may as well update the links to a working page.

We can revert this commit when the package urls are redirected to https://pkg.go.dev.