### PR TITLE
Upgrade to go-cmp v0.4.0

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -9,7 +9,7 @@
 
 [[constraint]]
   name = "github.com/google/go-cmp"
-  version = "0.2.0"
+  version = "0.4.0"
 
 [[constraint]]
   # Commit a53bc13 dropped support for go1.8. Pinning the previous commit for

--- a/assert/cmp/compare_test.go
+++ b/assert/cmp/compare_test.go
@@ -40,7 +40,7 @@ type Stub struct {
 
 func TestDeepEqualWithUnexported(t *testing.T) {
 	result := DeepEqual(Stub{}, Stub{unx: 1})()
-	assertFailureHasPrefix(t, result, `cannot handle unexported field: {cmp.Stub}.unx`)
+	assertFailureHasPrefix(t, result, `cannot handle unexported field at {cmp.Stub}.unx:`)
 }
 
 func TestRegexp(t *testing.T) {

--- a/assert/opt/opt_test.go
+++ b/assert/opt/opt_test.go
@@ -7,6 +7,7 @@ import (
 	gocmp "github.com/google/go-cmp/cmp"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/internal/source"
+	"gotest.tools/v3/skip"
 )
 
 func TestDurationWithThreshold(t *testing.T) {
@@ -172,6 +173,7 @@ func matchPaths(fixture interface{}, filter func(gocmp.Path) bool) []string {
 }
 
 func TestPathStringFromStruct(t *testing.T) {
+	skip.If(t, source.GoVersionLessThan(11), "expected value is different with go1.10")
 	fixture := node{
 		Ref: &node{
 			Children: []node{
@@ -200,6 +202,7 @@ func TestPathStringFromStruct(t *testing.T) {
 }
 
 func TestPathStringFromSlice(t *testing.T) {
+	skip.If(t, source.GoVersionLessThan(11), "expected value is different with go1.10")
 	fixture := []node{
 		{
 			Ref: &node{
@@ -237,6 +240,7 @@ func TestPathStringFromSlice(t *testing.T) {
 }
 
 func TestPathField(t *testing.T) {
+	skip.If(t, source.GoVersionLessThan(11), "expected value is different with go1.10")
 	fixture := node{
 		Value: nodeValue{Value: 3},
 		Children: []node{

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module gotest.tools/v3
 
 require (
-	github.com/google/go-cmp v0.3.0
+	github.com/google/go-cmp v0.4.0
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/pflag v1.0.3
 	golang.org/x/tools v0.0.0-20190624222133-a101b041ded4

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
-github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
+github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
@@ -11,3 +11,5 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190624222133-a101b041ded4 h1:1mMox4TgefDwqluYCv677yNXwlfTkija4owZve/jr78=
 golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
and adjust assert/cmp/compare_test.go accordingly.

In go-cmp v0.4.0, for user convenience, full name of the type
is printed in the panic message when accessing an unexported field,
see google/go-cmp#171

Many thanks!

Anthony