### PR TITLE
Prevent the panic

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -158,15 +158,20 @@ func logFailureFromBool(t TestingT, msgAndArgs ...interface{}) {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
 	}
-	const stackIndex = 3 // Assert()/Check(), assert(), formatFailureFromBool()
-	const comparisonArgPos = 1
+	const stackIndex = 3 // Assert()/Check(), assert(), logFailureFromBool()
 	args, err := source.CallExprArgs(stackIndex)
 	if err != nil {
 		t.Log(err.Error())
 		return
 	}
 
-	msg, err := boolFailureMessage(args[comparisonArgPos])
+	const comparisonArgIndex = 1 // Assert(t, comparison)
+	if len(args) <= comparisonArgIndex {
+		t.Log(failureMessage + "but assert failed to find the expression to print")
+		return
+	}
+
+	msg, err := boolFailureMessage(args[comparisonArgIndex])
 	if err != nil {
 		t.Log(err.Error())
 		msg = "expression is false"

--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -207,6 +207,16 @@ func TestCheckEqualFailure(t *testing.T) {
 	expectFailed(t, fakeT, "assertion failed: 5 (actual int) != 9 (expected int)")
 }
 
+func TestCheck_MultipleFunctionsOnTheSameLine(t *testing.T) {
+	fakeT := &fakeTestingT{}
+
+	f := func(b bool) {}
+	f(Check(fakeT, false))
+	// TODO: update the expected when there is a more correct fix
+	expectFailed(t, fakeT,
+		"assertion failed: but assert failed to find the expression to print")
+}
+
 func TestEqualSuccess(t *testing.T) {
 	fakeT := &fakeTestingT{}
 


### PR DESCRIPTION
Related to #195

Caused by multiple statements on the line. Doesn't fix the root cause, but at least fixes the panic.

I imagine this is probably still a good guard to have, even when the underlying bug is fixed.