### PR TITLE
poll: Result from cmp.Comparison

### DIFF
--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -53,10 +53,10 @@ func Eval(
 		t.Log(format.WithCustomMessage(failureMessage+msg, msgAndArgs...))
 
 	case cmp.Comparison:
-		success = runComparison(t, argSelector, check, msgAndArgs...)
+		success = RunComparison(t, argSelector, check, msgAndArgs...)
 
 	case func() cmp.Result:
-		success = runComparison(t, argSelector, check, msgAndArgs...)
+		success = RunComparison(t, argSelector, check, msgAndArgs...)
 
 	default:
 		t.Log(fmt.Sprintf("invalid Comparison: %v (%T)", check, check))

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -1,0 +1,143 @@
+package assert
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"reflect"
+
+	"gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/internal/format"
+	"gotest.tools/v3/internal/source"
+)
+
+// LogT is the subset of testing.T used by the assert package.
+type LogT interface {
+	Log(args ...interface{})
+}
+
+type helperT interface {
+	Helper()
+}
+
+const failureMessage = "assertion failed: "
+
+// Eval the comparison and print a failure messages if the comparison has failed.
+// nolint: gocyclo
+func Eval(
+	t LogT,
+	argSelector argSelector,
+	comparison interface{},
+	msgAndArgs ...interface{},
+) bool {
+	if ht, ok := t.(helperT); ok {
+		ht.Helper()
+	}
+	var success bool
+	switch check := comparison.(type) {
+	case bool:
+		if check {
+			return true
+		}
+		logFailureFromBool(t, msgAndArgs...)
+
+	// Undocumented legacy comparison without Result type
+	case func() (success bool, message string):
+		success = runCompareFunc(t, check, msgAndArgs...)
+
+	case nil:
+		return true
+
+	case error:
+		msg := failureMsgFromError(check)
+		t.Log(format.WithCustomMessage(failureMessage+msg, msgAndArgs...))
+
+	case cmp.Comparison:
+		success = runComparison(t, argSelector, check, msgAndArgs...)
+
+	case func() cmp.Result:
+		success = runComparison(t, argSelector, check, msgAndArgs...)
+
+	default:
+		t.Log(fmt.Sprintf("invalid Comparison: %v (%T)", check, check))
+	}
+	return success
+}
+
+func runCompareFunc(
+	t LogT,
+	f func() (success bool, message string),
+	msgAndArgs ...interface{},
+) bool {
+	if ht, ok := t.(helperT); ok {
+		ht.Helper()
+	}
+	if success, message := f(); !success {
+		t.Log(format.WithCustomMessage(failureMessage+message, msgAndArgs...))
+		return false
+	}
+	return true
+}
+
+func logFailureFromBool(t LogT, msgAndArgs ...interface{}) {
+	if ht, ok := t.(helperT); ok {
+		ht.Helper()
+	}
+	const stackIndex = 3 // Assert()/Check(), assert(), logFailureFromBool()
+	args, err := source.CallExprArgs(stackIndex)
+	if err != nil {
+		t.Log(err.Error())
+		return
+	}
+
+	const comparisonArgIndex = 1 // Assert(t, comparison)
+	if len(args) <= comparisonArgIndex {
+		t.Log(failureMessage + "but assert failed to find the expression to print")
+		return
+	}
+
+	msg, err := boolFailureMessage(args[comparisonArgIndex])
+	if err != nil {
+		t.Log(err.Error())
+		msg = "expression is false"
+	}
+
+	t.Log(format.WithCustomMessage(failureMessage+msg, msgAndArgs...))
+}
+
+func failureMsgFromError(err error) string {
+	// Handle errors with non-nil types
+	v := reflect.ValueOf(err)
+	if v.Kind() == reflect.Ptr && v.IsNil() {
+		return fmt.Sprintf("error is not nil: error has type %T", err)
+	}
+	return "error is not nil: " + err.Error()
+}
+
+func boolFailureMessage(expr ast.Expr) (string, error) {
+	if binaryExpr, ok := expr.(*ast.BinaryExpr); ok && binaryExpr.Op == token.NEQ {
+		x, err := source.FormatNode(binaryExpr.X)
+		if err != nil {
+			return "", err
+		}
+		y, err := source.FormatNode(binaryExpr.Y)
+		if err != nil {
+			return "", err
+		}
+		return x + " is " + y, nil
+	}
+
+	if unaryExpr, ok := expr.(*ast.UnaryExpr); ok && unaryExpr.Op == token.NOT {
+		x, err := source.FormatNode(unaryExpr.X)
+		if err != nil {
+			return "", err
+		}
+		return x + " is true", nil
+	}
+
+	formatted, err := source.FormatNode(expr)
+	if err != nil {
+		return "", err
+	}
+	return "expression is false: " + formatted, nil
+}

--- a/internal/assert/result.go
+++ b/internal/assert/result.go
@@ -9,7 +9,9 @@ import (
 	"gotest.tools/v3/internal/source"
 )
 
-func runComparison(
+// RunComparison and return Comparison.Success. If the comparison fails a messages
+// will be printed using t.Log.
+func RunComparison(
 	t LogT,
 	argSelector argSelector,
 	f cmp.Comparison,
@@ -26,7 +28,7 @@ func runComparison(
 	var message string
 	switch typed := result.(type) {
 	case resultWithComparisonArgs:
-		const stackIndex = 3 // Assert/Check, assert, runComparison
+		const stackIndex = 3 // Assert/Check, assert, RunComparison
 		args, err := source.CallExprArgs(stackIndex)
 		if err != nil {
 			t.Log(err.Error())
@@ -88,6 +90,8 @@ func isShortPrintableExpr(expr ast.Expr) bool {
 
 type argSelector func([]ast.Expr) []ast.Expr
 
+// ArgsAfterT selects args starting at position 1. Used when the caller has a
+// testing.T as the first argument, and the args to select should follow it.
 func ArgsAfterT(args []ast.Expr) []ast.Expr {
 	if len(args) < 1 {
 		return nil
@@ -95,11 +99,26 @@ func ArgsAfterT(args []ast.Expr) []ast.Expr {
 	return args[1:]
 }
 
+// ArgsFromComparisonCall selects args from the CallExpression at position 1.
+// Used when the caller has a testing.T as the first argument, and the args to
+// select are passed to the cmp.Comparison at position 1.
 func ArgsFromComparisonCall(args []ast.Expr) []ast.Expr {
-	if len(args) < 1 {
+	if len(args) <= 1 {
 		return nil
 	}
 	if callExpr, ok := args[1].(*ast.CallExpr); ok {
+		return callExpr.Args
+	}
+	return nil
+}
+
+// ArgsAtZeroIndex selects args from the CallExpression at position 1.
+// Used when the caller accepts a single cmp.Comparison argument.
+func ArgsAtZeroIndex(args []ast.Expr) []ast.Expr {
+	if len(args) == 0 {
+		return nil
+	}
+	if callExpr, ok := args[0].(*ast.CallExpr); ok {
 		return callExpr.Args
 	}
 	return nil

--- a/internal/assert/result.go
+++ b/internal/assert/result.go
@@ -10,7 +10,7 @@ import (
 )
 
 func runComparison(
-	t TestingT,
+	t LogT,
 	argSelector argSelector,
 	f cmp.Comparison,
 	msgAndArgs ...interface{},
@@ -88,14 +88,14 @@ func isShortPrintableExpr(expr ast.Expr) bool {
 
 type argSelector func([]ast.Expr) []ast.Expr
 
-func argsAfterT(args []ast.Expr) []ast.Expr {
+func ArgsAfterT(args []ast.Expr) []ast.Expr {
 	if len(args) < 1 {
 		return nil
 	}
 	return args[1:]
 }
 
-func argsFromComparisonCall(args []ast.Expr) []ast.Expr {
+func ArgsFromComparisonCall(args []ast.Expr) []ast.Expr {
 	if len(args) < 1 {
 		return nil
 	}

--- a/poll/poll_test.go
+++ b/poll/poll_test.go
@@ -73,3 +73,16 @@ func TestWaitOnWithCheckError(t *testing.T) {
 	assert.Assert(t, cmp.Panics(func() { WaitOn(fakeT, check) }))
 	assert.Equal(t, "polling check failed: broke", fakeT.failed)
 }
+
+func TestWaitOn_WithCompare(t *testing.T) {
+	fakeT := &fakeT{}
+
+	check := func(t LogT) Result {
+		return Compare(cmp.Equal(3, 4))
+	}
+
+	assert.Assert(t, cmp.Panics(func() {
+		WaitOn(fakeT, check, WithDelay(0), WithTimeout(10*time.Millisecond))
+	}))
+	assert.Assert(t, cmp.Contains(fakeT.failed, "assertion failed: 3 (int) != 4 (int)"))
+}


### PR DESCRIPTION
This change allows `poll.Check` functions to use `cmp.Comparison` to indicate `Success` or `Continue`.