### PR TITLE
Fix compare_test.go for go-cmp 0.4

### DIFF
--- a/assert/cmp/compare_test.go
+++ b/assert/cmp/compare_test.go
@@ -40,7 +40,7 @@ type Stub struct {
 
 func TestDeepEqualWithUnexported(t *testing.T) {
 	result := DeepEqual(Stub{}, Stub{unx: 1})()
-	assertFailureHasPrefix(t, result, `cannot handle unexported field: {cmp.Stub}.unx`)
+	assertFailureHasPrefix(t, result, `cannot handle unexported field at {cmp.Stub}.unx`)
 }
 
 func TestRegexp(t *testing.T) {


### PR DESCRIPTION
DO NOT MERGE this MR before updating google/go-cmp 0.4 (ie. do not merge it now).

This commit fixes a test in `compare_test.go` for google/go-cmp 0.4.

See commit 776445f29feeb6041579ae3df3c5615aba0fa128 in google/go-cmp for details.