### PR TITLE
Remove import aliases

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -62,7 +62,7 @@ See http://pkg.go.dev/gotest.tools/v3/assert/cmd/gty-migrate-from-testify.
 
 
 */
-package assert // import "gotest.tools/v3/assert"
+package assert
 
 import (
 	gocmp "github.com/google/go-cmp/cmp"

--- a/assert/cmp/compare.go
+++ b/assert/cmp/compare.go
@@ -1,5 +1,5 @@
 /*Package cmp provides Comparisons for Assert and Check*/
-package cmp // import "gotest.tools/v3/assert/cmp"
+package cmp
 
 import (
 	"fmt"

--- a/assert/opt/opt.go
+++ b/assert/opt/opt.go
@@ -1,6 +1,6 @@
 /*Package opt provides common go-cmp.Options for use with assert.DeepEqual.
  */
-package opt // import "gotest.tools/v3/assert/opt"
+package opt
 
 import (
 	"fmt"

--- a/env/env.go
+++ b/env/env.go
@@ -1,7 +1,7 @@
 /*Package env provides functions to test code that read environment variables
 or the current working directory.
 */
-package env // import "gotest.tools/v3/env"
+package env
 
 import (
 	"os"

--- a/fs/file.go
+++ b/fs/file.go
@@ -1,7 +1,7 @@
 /*Package fs provides tools for creating temporary files, and testing the
 contents and structure of a directory.
 */
-package fs // import "gotest.tools/v3/fs"
+package fs
 
 import (
 	"io/ioutil"

--- a/golden/golden.go
+++ b/golden/golden.go
@@ -5,7 +5,7 @@ Golden files can be automatically updated to match new values by running
 `go test pkgname -test.update-golden`. To ensure the update is correct
 compare the diff of the old expected value to the new expected value.
 */
-package golden // import "gotest.tools/v3/golden"
+package golden
 
 import (
 	"bytes"

--- a/icmd/command.go
+++ b/icmd/command.go
@@ -1,6 +1,6 @@
 /*Package icmd executes binaries and provides convenient assertions for testing the results.
  */
-package icmd // import "gotest.tools/v3/icmd"
+package icmd
 
 import (
 	"bytes"

--- a/internal/difflib/difflib.go
+++ b/internal/difflib/difflib.go
@@ -4,7 +4,7 @@ Original source: https://github.com/pmezard/go-difflib
 
 This file is trimmed to only the parts used by this repository.
 */
-package difflib // import "gotest.tools/v3/internal/difflib"
+package difflib
 
 func min(a, b int) int {
 	if a < b {

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -1,4 +1,4 @@
-package format // import "gotest.tools/v3/internal/format"
+package format
 
 import "fmt"
 

--- a/internal/maint/maint.go
+++ b/internal/maint/maint.go
@@ -1,4 +1,4 @@
-package maint // import "gotest.tools/v3/internal/maint"
+package maint
 
 import (
 	"fmt"

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -1,4 +1,4 @@
-package source // import "gotest.tools/v3/internal/source"
+package source
 
 import (
 	"bytes"

--- a/pkg.go
+++ b/pkg.go
@@ -1,4 +1,4 @@
 /*Package gotesttools is a collection of packages to augment `testing` and
 support common patterns.
 */
-package gotesttools // import "gotest.tools/v3"
+package gotesttools

--- a/poll/poll.go
+++ b/poll/poll.go
@@ -1,6 +1,6 @@
 /*Package poll provides tools for testing asynchronous code.
  */
-package poll // import "gotest.tools/v3/poll"
+package poll
 
 import (
 	"fmt"

--- a/skip/skip.go
+++ b/skip/skip.go
@@ -1,7 +1,7 @@
 /*Package skip provides functions for skipping a test and printing the source code
 of the condition used to skip the test.
 */
-package skip // import "gotest.tools/v3/skip"
+package skip
 
 import (
 	"fmt"

--- a/x/doc.go
+++ b/x/doc.go
@@ -2,4 +2,4 @@
 compatibility requirements. Packages in this namespace may contain backwards
 incompatible changes within the same major version.
 */
-package x // import "gotest.tools/v3/x"
+package x

--- a/x/subtest/context.go
+++ b/x/subtest/context.go
@@ -10,7 +10,7 @@ little value. A context.Context can be managed by tests that need it with
 little enough boilerplate that it doesn't make sense to wrap testing.T in a
 TestContext.
 */
-package subtest // import "gotest.tools/v3/x/subtest"
+package subtest
 
 import (
 	"context"


### PR DESCRIPTION
The import aliases break the so-called so-called “minimal module
support” in GOPATH mode. Removing them does not seem to harm.

See <https://github.com/gotestyourself/gotest.tools/issues/203>

Removing them all with a one-liner:

    find -name '*.go' | xargs sed -i 's; // import.*$;;'

Signed-off-by: Arnaud Rebillout <arnaud.rebillout@collabora.com>