### PR TITLE
assert: look for the right function call in the source

### DIFF
--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -1,4 +1,4 @@
-package assert
+package assert_test
 
 import (
 	"fmt"
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	gocmp "github.com/google/go-cmp/cmp"
+	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
 )
 
@@ -32,7 +33,7 @@ func (f *fakeTestingT) Helper() {}
 func TestAssertWithBoolFailure(t *testing.T) {
 	fakeT := &fakeTestingT{}
 
-	Assert(fakeT, 1 == 6)
+	assert.Assert(fakeT, 1 == 6)
 	expectFailNowed(t, fakeT, "assertion failed: expression is false: 1 == 6")
 }
 
@@ -40,7 +41,7 @@ func TestAssertWithBoolFailureNotEqual(t *testing.T) {
 	fakeT := &fakeTestingT{}
 
 	var err error
-	Assert(fakeT, err != nil)
+	assert.Assert(fakeT, err != nil)
 	expectFailNowed(t, fakeT, "assertion failed: err is nil")
 }
 
@@ -48,14 +49,14 @@ func TestAssertWithBoolFailureNotTrue(t *testing.T) {
 	fakeT := &fakeTestingT{}
 
 	badNews := true
-	Assert(fakeT, !badNews)
+	assert.Assert(fakeT, !badNews)
 	expectFailNowed(t, fakeT, "assertion failed: badNews is true")
 }
 
 func TestAssertWithBoolFailureAndExtraMessage(t *testing.T) {
 	fakeT := &fakeTestingT{}
 
-	Assert(fakeT, 1 > 5, "sometimes things fail")
+	assert.Assert(fakeT, 1 > 5, "sometimes things fail")
 	expectFailNowed(t, fakeT,
 		"assertion failed: expression is false: 1 > 5: sometimes things fail")
 }
@@ -63,14 +64,14 @@ func TestAssertWithBoolFailureAndExtraMessage(t *testing.T) {
 func TestAssertWithBoolSuccess(t *testing.T) {
 	fakeT := &fakeTestingT{}
 
-	Assert(fakeT, 1 < 5)
+	assert.Assert(fakeT, 1 < 5)
 	expectSuccess(t, fakeT)
 }
 
 func TestAssertWithBoolMultiLineFailure(t *testing.T) {
 	fakeT := &fakeTestingT{}
 
-	Assert(fakeT, func() bool {
+	assert.Assert(fakeT, func() bool {
 		for range []int{1, 2, 3, 4} {
 		}
 		return false
@@ -95,7 +96,7 @@ func TestAssertWithComparisonSuccess(t *testing.T) {
 	fakeT := &fakeTestingT{}
 
 	cmp := exampleComparison{success: true}
-	Assert(fakeT, cmp.Compare)
+	assert.Assert(fakeT, cmp.Compare)
 	expectSuccess(t, fakeT)
 }
 
@@ -103,7 +104,7 @@ func TestAssertWithComparisonFailure(t *testing.T) {
 	fakeT := &fakeTestingT{}
 
 	cmp := exampleComparison{message: "oops, not good"}
-	Assert(fakeT, cmp.Compare)
+	assert.Assert(fakeT, cmp.Compare)
 	expectFailNowed(t, fakeT, "assertion failed: oops, not good")
 }
 
@@ -111,7 +112,7 @@ func TestAssertWithComparisonAndExtraMessage(t *testing.T) {
 	fakeT := &fakeTestingT{}
 
 	cmp := exampleComparison{message: "oops, not good"}
-	Assert(fakeT, cmp.Compare, "extra stuff %v", true)
+	assert.Assert(fakeT, cmp.Compare, "extra stuff %v", true)
 	expectFailNowed(t, fakeT, "assertion failed: oops, not good: extra stuff true")
 }
 
@@ -130,41 +131,41 @@ func TestNilError(t *testing.T) {
 	t.Run("nil interface", func(t *testing.T) {
 		fakeT := &fakeTestingT{}
 		var err error
-		NilError(fakeT, err)
+		assert.NilError(fakeT, err)
 		expectSuccess(t, fakeT)
 	})
 
 	t.Run("nil literal", func(t *testing.T) {
 		fakeT := &fakeTestingT{}
-		NilError(fakeT, nil)
+		assert.NilError(fakeT, nil)
 		expectSuccess(t, fakeT)
 	})
 
 	t.Run("interface with non-nil type", func(t *testing.T) {
 		fakeT := &fakeTestingT{}
 		var customErr *customError
-		NilError(fakeT, customErr)
-		expected := "assertion failed: error is not nil: error has type *assert.customError"
+		assert.NilError(fakeT, customErr)
+		expected := "assertion failed: error is not nil: error has type *assert_test.customError"
 		expectFailNowed(t, fakeT, expected)
 	})
 
 	t.Run("non-nil error", func(t *testing.T) {
 		fakeT := &fakeTestingT{}
-		NilError(fakeT, fmt.Errorf("this is the error"))
+		assert.NilError(fakeT, fmt.Errorf("this is the error"))
 		expectFailNowed(t, fakeT, "assertion failed: error is not nil: this is the error")
 	})
 
 	t.Run("non-nil error with struct type", func(t *testing.T) {
 		fakeT := &fakeTestingT{}
 		err := structError{}
-		NilError(fakeT, err)
+		assert.NilError(fakeT, err)
 		expectFailNowed(t, fakeT, "assertion failed: error is not nil: this is a struct")
 	})
 
 	t.Run("non-nil error with map type", func(t *testing.T) {
 		fakeT := &fakeTestingT{}
 		var err mapError
-		NilError(fakeT, err)
+		assert.NilError(fakeT, err)
 		expectFailNowed(t, fakeT, "assertion failed: error is not nil: ")
 	})
 }
@@ -184,7 +185,7 @@ func (m mapError) Error() string {
 func TestCheckFailure(t *testing.T) {
 	fakeT := &fakeTestingT{}
 
-	if Check(fakeT, 1 == 2) {
+	if assert.Check(fakeT, 1 == 2) {
 		t.Error("expected check to return false on failure")
 	}
 	expectFailed(t, fakeT, "assertion failed: expression is false: 1 == 2")
@@ -193,7 +194,7 @@ func TestCheckFailure(t *testing.T) {
 func TestCheckSuccess(t *testing.T) {
 	fakeT := &fakeTestingT{}
 
-	if !Check(fakeT, true) {
+	if !assert.Check(fakeT, true) {
 		t.Error("expected check to return true on success")
 	}
 	expectSuccess(t, fakeT)
@@ -203,7 +204,7 @@ func TestCheckEqualFailure(t *testing.T) {
 	fakeT := &fakeTestingT{}
 
 	actual, expected := 5, 9
-	Check(fakeT, cmp.Equal(actual, expected))
+	assert.Check(fakeT, cmp.Equal(actual, expected))
 	expectFailed(t, fakeT, "assertion failed: 5 (actual int) != 9 (expected int)")
 }
 
@@ -211,19 +212,17 @@ func TestCheck_MultipleFunctionsOnTheSameLine(t *testing.T) {
 	fakeT := &fakeTestingT{}
 
 	f := func(b bool) {}
-	f(Check(fakeT, false))
-	// TODO: update the expected when there is a more correct fix
-	expectFailed(t, fakeT,
-		"assertion failed: but assert failed to find the expression to print")
+	f(assert.Check(fakeT, false))
+	expectFailed(t, fakeT, "assertion failed: expression is false: false")
 }
 
 func TestEqualSuccess(t *testing.T) {
 	fakeT := &fakeTestingT{}
 
-	Equal(fakeT, 1, 1)
+	assert.Equal(fakeT, 1, 1)
 	expectSuccess(t, fakeT)
 
-	Equal(fakeT, "abcd", "abcd")
+	assert.Equal(fakeT, "abcd", "abcd")
 	expectSuccess(t, fakeT)
 }
 
@@ -231,14 +230,14 @@ func TestEqualFailure(t *testing.T) {
 	fakeT := &fakeTestingT{}
 
 	actual, expected := 1, 3
-	Equal(fakeT, actual, expected)
+	assert.Equal(fakeT, actual, expected)
 	expectFailNowed(t, fakeT, "assertion failed: 1 (actual int) != 3 (expected int)")
 }
 
 func TestEqualFailureTypes(t *testing.T) {
 	fakeT := &fakeTestingT{}
 
-	Equal(fakeT, 3, uint(3))
+	assert.Equal(fakeT, 3, uint(3))
 	expectFailNowed(t, fakeT, `assertion failed: 3 (int) != 3 (uint)`)
 }
 
@@ -250,7 +249,7 @@ func TestEqualFailureWithSelectorArgument(t *testing.T) {
 	}
 	var testcase = tc{expected: "foo"}
 
-	Equal(fakeT, "ok", testcase.expected)
+	assert.Equal(fakeT, "ok", testcase.expected)
 	expectFailNowed(t, fakeT,
 		"assertion failed: ok (string) != foo (testcase.expected string)")
 }
@@ -259,7 +258,7 @@ func TestEqualFailureWithIndexExpr(t *testing.T) {
 	fakeT := &fakeTestingT{}
 
 	expected := map[string]string{"foo": "bar"}
-	Equal(fakeT, "ok", expected["foo"])
+	assert.Equal(fakeT, "ok", expected["foo"])
 	expectFailNowed(t, fakeT,
 		`assertion failed: ok (string) != bar (expected["foo"] string)`)
 }
@@ -267,7 +266,7 @@ func TestEqualFailureWithIndexExpr(t *testing.T) {
 func TestEqualFailureWithCallExprArgument(t *testing.T) {
 	fakeT := &fakeTestingT{}
 	ce := customError{}
-	Equal(fakeT, "", ce.Error())
+	assert.Equal(fakeT, "", ce.Error())
 	expectFailNowed(t, fakeT,
 		"assertion failed:  (string) != custom error (string)")
 }
@@ -278,7 +277,7 @@ func TestAssertFailureWithOfflineComparison(t *testing.T) {
 	b := 2
 	// store comparison in a variable, so ast lookup can't find it
 	comparison := cmp.Equal(a, b)
-	Assert(fakeT, comparison)
+	assert.Assert(fakeT, comparison)
 	// expected value wont have variable names
 	expectFailNowed(t, fakeT, "assertion failed: 1 (int) != 2 (int)")
 }
@@ -286,12 +285,11 @@ func TestAssertFailureWithOfflineComparison(t *testing.T) {
 type testingT interface {
 	Errorf(msg string, args ...interface{})
 	Fatalf(msg string, args ...interface{})
+	Helper()
 }
 
 func expectFailNowed(t testingT, fakeT *fakeTestingT, expected string) {
-	if ht, ok := t.(helperT); ok {
-		ht.Helper()
-	}
+	t.Helper()
 	if fakeT.failed {
 		t.Errorf("should not have failed, got messages %s", fakeT.msgs)
 	}
@@ -305,9 +303,7 @@ func expectFailNowed(t testingT, fakeT *fakeTestingT, expected string) {
 
 // nolint: unparam
 func expectFailed(t testingT, fakeT *fakeTestingT, expected string) {
-	if ht, ok := t.(helperT); ok {
-		ht.Helper()
-	}
+	t.Helper()
 	if fakeT.failNowed {
 		t.Errorf("should not have failNowed, got messages %s", fakeT.msgs)
 	}
@@ -320,9 +316,7 @@ func expectFailed(t testingT, fakeT *fakeTestingT, expected string) {
 }
 
 func expectSuccess(t testingT, fakeT *fakeTestingT) {
-	if ht, ok := t.(helperT); ok {
-		ht.Helper()
-	}
+	t.Helper()
 	if fakeT.failNowed {
 		t.Errorf("should not have failNowed, got messages %s", fakeT.msgs)
 	}
@@ -341,7 +335,7 @@ func TestDeepEqualSuccess(t *testing.T) {
 	expected := stub{"ok", 1}
 
 	fakeT := &fakeTestingT{}
-	DeepEqual(fakeT, actual, expected, gocmp.AllowUnexported(stub{}))
+	assert.DeepEqual(fakeT, actual, expected, gocmp.AllowUnexported(stub{}))
 	expectSuccess(t, fakeT)
 }
 
@@ -350,7 +344,7 @@ func TestDeepEqualFailure(t *testing.T) {
 	expected := stub{"ok", 2}
 
 	fakeT := &fakeTestingT{}
-	DeepEqual(fakeT, actual, expected, gocmp.AllowUnexported(stub{}))
+	assert.DeepEqual(fakeT, actual, expected, gocmp.AllowUnexported(stub{}))
 	if !fakeT.failNowed {
 		t.Fatal("should have failNowed")
 	}
@@ -361,14 +355,14 @@ func TestErrorFailure(t *testing.T) {
 		fakeT := &fakeTestingT{}
 
 		var err error
-		Error(fakeT, err, "this error")
+		assert.Error(fakeT, err, "this error")
 		expectFailNowed(t, fakeT, "assertion failed: expected an error, got nil")
 	})
 	t.Run("different error", func(t *testing.T) {
 		fakeT := &fakeTestingT{}
 
 		err := fmt.Errorf("the actual error")
-		Error(fakeT, err, "this error")
+		assert.Error(fakeT, err, "this error")
 		expected := `assertion failed: expected error "this error", got "the actual error"`
 		expectFailNowed(t, fakeT, expected)
 	})
@@ -379,14 +373,14 @@ func TestErrorContainsFailure(t *testing.T) {
 		fakeT := &fakeTestingT{}
 
 		var err error
-		ErrorContains(fakeT, err, "this error")
+		assert.ErrorContains(fakeT, err, "this error")
 		expectFailNowed(t, fakeT, "assertion failed: expected an error, got nil")
 	})
 	t.Run("different error", func(t *testing.T) {
 		fakeT := &fakeTestingT{}
 
 		err := fmt.Errorf("the actual error")
-		ErrorContains(fakeT, err, "this error")
+		assert.ErrorContains(fakeT, err, "this error")
 		expected := `assertion failed: expected error to contain "this error", got "the actual error"`
 		expectFailNowed(t, fakeT, expected)
 	})
@@ -397,14 +391,14 @@ func TestErrorTypeFailure(t *testing.T) {
 		fakeT := &fakeTestingT{}
 
 		var err error
-		ErrorType(fakeT, err, os.IsNotExist)
+		assert.ErrorType(fakeT, err, os.IsNotExist)
 		expectFailNowed(t, fakeT, "assertion failed: error is nil, not os.IsNotExist")
 	})
 	t.Run("different error", func(t *testing.T) {
 		fakeT := &fakeTestingT{}
 
 		err := fmt.Errorf("the actual error")
-		ErrorType(fakeT, err, os.IsNotExist)
+		assert.ErrorType(fakeT, err, os.IsNotExist)
 		expected := `assertion failed: error is the actual error (*errors.errorString), not os.IsNotExist`
 		expectFailNowed(t, fakeT, expected)
 	})

--- a/internal/source/defers.go
+++ b/internal/source/defers.go
@@ -29,13 +29,12 @@ func guessDefer(node ast.Node) (ast.Node, error) {
 	defers := collectDefers(node)
 	switch len(defers) {
 	case 0:
-		return nil, errors.New("failed to expression in defer")
+		return nil, errors.New("failed to find expression in defer")
 	case 1:
 		return defers[0].Call, nil
 	default:
-		return nil, errors.Errorf(
-			"ambiguous call expression: multiple (%d) defers in call block",
-			len(defers))
+		msg := "ambiguous call expression: multiple (%d) defers in call block"
+		return nil, errors.Errorf(msg, len(defers))
 	}
 }
 

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -8,6 +8,7 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
+	"path"
 	"runtime"
 	"strconv"
 	"strings"
@@ -39,32 +40,65 @@ func CallExprArgs(stackIndex int) ([]ast.Expr, error) {
 	}
 	debug("call stack position: %s:%d", filename, lineNum)
 
-	node, err := getNodeAtLine(filename, lineNum)
+	source, err := getNodeAtLine(filename, lineNum)
 	if err != nil {
 		return nil, err
 	}
-	debug("found node: %s", debugFormatNode{node})
+	debug("found node: %s", debugFormatNode{source.Node})
 
-	return getCallExprArgs(node)
+	return getCallExprArgs(source)
 }
 
-func getNodeAtLine(filename string, lineNum int) (ast.Node, error) {
+type fileSource struct {
+	Node    ast.Node
+	Imports imports
+}
+
+type imports map[string]struct{}
+
+func newImports(specs []*ast.ImportSpec) imports {
+	result := make(imports)
+	for _, spec := range specs {
+		pkgPath := strings.Trim(spec.Path.Value, `"`)
+		if !strings.HasPrefix(pkgPath, `gotest.tools/`) {
+			continue
+		}
+		name := path.Base(pkgPath)
+		// Only two packages use internal/source right now.
+		// Don't include the others to reduce the chance of a false positive
+		// match on the name of some other package or type.
+		if name != "assert" && name != "skip" {
+			continue
+		}
+		if spec.Name != nil {
+			name = spec.Name.Name
+		}
+		result[name] = struct{}{}
+	}
+	return result
+}
+
+func getNodeAtLine(filename string, lineNum int) (fileSource, error) {
+	fs := fileSource{}
 	fileset := token.NewFileSet()
 	astFile, err := parser.ParseFile(fileset, filename, nil, parser.AllErrors)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse source file: %s", filename)
+		return fs, errors.Wrapf(err, "failed to parse source file: %s", filename)
 	}
+	fs.Imports = newImports(astFile.Imports)
 
 	if node := scanToLine(fileset, astFile, lineNum); node != nil {
-		return node, nil
+		fs.Node = node
+		return fs, nil
 	}
 	if node := scanToDeferLine(fileset, astFile, lineNum); node != nil {
 		node, err := guessDefer(node)
 		if err != nil || node != nil {
-			return node, err
+			fs.Node = node
+			return fs, err
 		}
 	}
-	return nil, errors.Errorf("failed to find an expression on line %d in %s", lineNum, filename)
+	return fs, errors.Errorf("failed to find an expression on line %d in %s", lineNum, filename)
 }
 
 func scanToLine(fileset *token.FileSet, node ast.Node, lineNum int) ast.Node {
@@ -121,9 +155,9 @@ func GoVersionLessThan(major, minor int64) bool {
 
 var goVersionBefore19 = GoVersionLessThan(1, 9)
 
-func getCallExprArgs(node ast.Node) ([]ast.Expr, error) {
-	visitor := &callExprVisitor{}
-	ast.Walk(visitor, node)
+func getCallExprArgs(source fileSource) ([]ast.Expr, error) {
+	visitor := &callExprVisitor{imports: source.Imports}
+	ast.Walk(visitor, source.Node)
 	if visitor.expr == nil {
 		return nil, errors.New("failed to find call expression")
 	}
@@ -132,7 +166,8 @@ func getCallExprArgs(node ast.Node) ([]ast.Expr, error) {
 }
 
 type callExprVisitor struct {
-	expr *ast.CallExpr
+	expr    *ast.CallExpr
+	imports imports
 }
 
 func (v *callExprVisitor) Visit(node ast.Node) ast.Visitor {
@@ -143,7 +178,7 @@ func (v *callExprVisitor) Visit(node ast.Node) ast.Visitor {
 
 	switch typed := node.(type) {
 	case *ast.CallExpr:
-		if !isGoTestToolsCallExpr(typed) {
+		if !isGoTestToolsCallExpr(typed, v.imports) {
 			return v
 		}
 		v.expr = typed
@@ -155,7 +190,7 @@ func (v *callExprVisitor) Visit(node ast.Node) ast.Visitor {
 	return v
 }
 
-func isGoTestToolsCallExpr(ce *ast.CallExpr) bool {
+func isGoTestToolsCallExpr(ce *ast.CallExpr, imports imports) bool {
 	debug("call expr function: (%T), %v", ce.Fun, ce.Fun)
 	se, ok := ce.Fun.(*ast.SelectorExpr)
 	if !ok {
@@ -165,15 +200,19 @@ func isGoTestToolsCallExpr(ce *ast.CallExpr) bool {
 	if !ok {
 		return false
 	}
-	switch ident.Name {
-	// TODO: use import alias from file for these values
-	case "assert", "skip":
+	switch {
+	case imports.isGoTestToolsPackageSelector(ident.Name):
 		return true
-	case "gotestToolsTestShim":
+	case ident.Name == "gotestToolsTestShim":
 		// gotestToolsTestShim is used by tests of this package.
 		return true
 	}
 	return false
+}
+
+func (i imports) isGoTestToolsPackageSelector(name string) bool {
+	_, ok := i[name]
+	return ok
 }
 
 // FormatNode using go/format.Node and return the result as a string

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -64,8 +64,7 @@ func getNodeAtLine(filename string, lineNum int) (ast.Node, error) {
 			return node, err
 		}
 	}
-	return nil, errors.Errorf(
-		"failed to find an expression on line %d in %s", lineNum, filename)
+	return nil, errors.Errorf("failed to find an expression on line %d in %s", lineNum, filename)
 }
 
 func scanToLine(fileset *token.FileSet, node ast.Node, lineNum int) ast.Node {

--- a/skip/skip_test.go
+++ b/skip/skip_test.go
@@ -1,4 +1,4 @@
-package skip
+package skip_test
 
 import (
 	"bytes"
@@ -7,6 +7,7 @@ import (
 
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/skip"
 )
 
 type fakeSkipT struct {
@@ -28,14 +29,10 @@ func (f *fakeSkipT) Log(args ...interface{}) {
 
 func (f *fakeSkipT) Helper() {}
 
-func version(v string) string {
-	return v
-}
-
 func TestIfCondition(t *testing.T) {
 	skipT := &fakeSkipT{}
 	apiVersion := "v1.4"
-	If(skipT, apiVersion < version("v1.6"))
+	skip.If(skipT, apiVersion < version("v1.6"))
 
 	assert.Equal(t, `apiVersion < version("v1.6")`, skipT.reason)
 	assert.Assert(t, cmp.Len(skipT.logs, 0))
@@ -44,7 +41,7 @@ func TestIfCondition(t *testing.T) {
 func TestIfConditionWithMessage(t *testing.T) {
 	skipT := &fakeSkipT{}
 	apiVersion := "v1.4"
-	If(skipT, apiVersion < "v1.6", "see notes")
+	skip.If(skipT, apiVersion < "v1.6", "see notes")
 
 	assert.Equal(t, `apiVersion < "v1.6": see notes`, skipT.reason)
 	assert.Assert(t, cmp.Len(skipT.logs, 0))
@@ -53,7 +50,7 @@ func TestIfConditionWithMessage(t *testing.T) {
 func TestIfConditionMultiline(t *testing.T) {
 	skipT := &fakeSkipT{}
 	apiVersion := "v1.4"
-	If(
+	skip.If(
 		skipT,
 		apiVersion < "v1.6")
 
@@ -64,7 +61,7 @@ func TestIfConditionMultiline(t *testing.T) {
 func TestIfConditionMultilineWithMessage(t *testing.T) {
 	skipT := &fakeSkipT{}
 	apiVersion := "v1.4"
-	If(
+	skip.If(
 		skipT,
 		apiVersion < "v1.6",
 		"see notes")
@@ -75,7 +72,7 @@ func TestIfConditionMultilineWithMessage(t *testing.T) {
 
 func TestIfConditionNoSkip(t *testing.T) {
 	skipT := &fakeSkipT{}
-	If(skipT, false)
+	skip.If(skipT, false)
 
 	assert.Equal(t, "", skipT.reason)
 	assert.Assert(t, cmp.Len(skipT.logs, 0))
@@ -87,14 +84,14 @@ func SkipBecauseISaidSo() bool {
 
 func TestIf(t *testing.T) {
 	skipT := &fakeSkipT{}
-	If(skipT, SkipBecauseISaidSo)
+	skip.If(skipT, SkipBecauseISaidSo)
 
 	assert.Equal(t, "SkipBecauseISaidSo", skipT.reason)
 }
 
 func TestIfWithMessage(t *testing.T) {
 	skipT := &fakeSkipT{}
-	If(skipT, SkipBecauseISaidSo, "see notes")
+	skip.If(skipT, SkipBecauseISaidSo, "see notes")
 
 	assert.Equal(t, "SkipBecauseISaidSo: see notes", skipT.reason)
 }
@@ -102,26 +99,26 @@ func TestIfWithMessage(t *testing.T) {
 func TestIf_InvalidCondition(t *testing.T) {
 	skipT := &fakeSkipT{}
 	assert.Assert(t, cmp.Panics(func() {
-		If(skipT, "just a string")
+		skip.If(skipT, "just a string")
 	}))
 }
 
 func TestIfWithSkipResultFunc(t *testing.T) {
 	t.Run("no extra message", func(t *testing.T) {
 		skipT := &fakeSkipT{}
-		If(skipT, alwaysSkipWithMessage)
+		skip.If(skipT, alwaysSkipWithMessage)
 
 		assert.Equal(t, "alwaysSkipWithMessage: skip because I said so!", skipT.reason)
 	})
 	t.Run("with extra message", func(t *testing.T) {
 		skipT := &fakeSkipT{}
-		If(skipT, alwaysSkipWithMessage, "also %v", 4)
+		skip.If(skipT, alwaysSkipWithMessage, "also %v", 4)
 
 		assert.Equal(t, "alwaysSkipWithMessage: skip because I said so!: also 4", skipT.reason)
 	})
 }
 
-func alwaysSkipWithMessage() Result {
+func alwaysSkipWithMessage() skip.Result {
 	return skipResult{}
 }
 


### PR DESCRIPTION
Fixes #195

Required moving all the tests which used `internal/source` to external test packages.

When scanning for an `ast.CallExpr` only consider those that use a `ast.SelectorExpr` where the name of the `X` is a gotest.tools package. That way if there are other function calls on the line, it will continue looking for the right call.

This makes the lookup logic more complicated, and will break if someone assigns `assert.<func>` to a local var. Hopefully that is not a common practice.