### PR TITLE
go.mod: update dependencies

### DIFF
--- a/assert/opt/opt_test.go
+++ b/assert/opt/opt_test.go
@@ -1,6 +1,7 @@
 package opt
 
 import (
+	"sort"
 	"testing"
 	"time"
 
@@ -167,6 +168,7 @@ func (p *pathRecorder) record(path gocmp.Path) bool {
 func matchPaths(fixture interface{}, filter func(gocmp.Path) bool) []string {
 	rec := &pathRecorder{filter: filter}
 	gocmp.Equal(fixture, fixture, gocmp.FilterPath(rec.record, gocmp.Ignore()))
+	sort.Strings(rec.matches)
 	return rec.matches
 }
 
@@ -236,15 +238,15 @@ func TestPathField(t *testing.T) {
 	filter := PathField(nodeValue{}, "Value")
 	matches := matchPaths(fixture, filter)
 	expected := []string{
+		"{opt.node}.Children[0].Value.Value",
+		"{opt.node}.Children[0].Value.Value",
+		"{opt.node}.Children[1].Value.Value",
+		"{opt.node}.Children[1].Value.Value",
+		"{opt.node}.Children[2].Ref.Value.Value",
+		"{opt.node}.Children[2].Ref.Value.Value",
+		"{opt.node}.Children[2].Value.Value",
+		"{opt.node}.Children[2].Value.Value",
 		"{opt.node}.Value.Value",
-		"{opt.node}.Children[0].Value.Value",
-		"{opt.node}.Children[1].Value.Value",
-		"{opt.node}.Children[2].Value.Value",
-		"{opt.node}.Children[2].Ref.Value.Value",
-		"{opt.node}.Children[0].Value.Value",
-		"{opt.node}.Children[1].Value.Value",
-		"{opt.node}.Children[2].Value.Value",
-		"{opt.node}.Children[2].Ref.Value.Value",
 	}
 	assert.DeepEqual(t, matches, expected)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module gotest.tools/v3
 
 require (
-	github.com/google/go-cmp v0.4.0
+	github.com/google/go-cmp v0.5.5
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.3
 	golang.org/x/tools v0.0.0-20190624222133-a101b041ded4

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module gotest.tools/v3
 
 require (
 	github.com/google/go-cmp v0.4.0
-	github.com/pkg/errors v0.8.1
+	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.3
 	golang.org/x/tools v0.0.0-20190624222133-a101b041ded4
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
-github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
### go.mod: github.com/pkg/errors v0.9.1

This version provides compatibility with Go 1.3+ native error wrapping

### go.mod: github.com/google/go-cmp v0.5.5

Version v0.5.x provides various improvements to  the reporter output;
https://github.com/google/go-cmp/releases

full diff: https://github.com/google/go-cmp/compare/v0.4.0...v0.5.5

