### PR TITLE
fs: add DirFromPath

### DIFF
--- a/fs/file.go
+++ b/fs/file.go
@@ -113,3 +113,19 @@ func (d *Dir) Remove() {
 func (d *Dir) Join(parts ...string) string {
 	return filepath.Join(append([]string{d.Path()}, parts...)...)
 }
+
+// DirFromPath returns a Dir for a path that already exists. No directory is created.
+// Unlike NewDir the directory will not be removed automatically when the test exits,
+// it is the callers responsibly to remove the directory.
+// DirFromPath can be used with Apply to modify an existing directory.
+//
+// If the path does not already exist, use NewDir instead.
+func DirFromPath(t assert.TestingT, path string, ops ...PathOp) *Dir {
+	if ht, ok := t.(helperT); ok {
+		ht.Helper()
+	}
+
+	dir := &Dir{path: path}
+	assert.NilError(t, applyPathOps(dir, ops))
+	return dir
+}

--- a/fs/file_test.go
+++ b/fs/file_test.go
@@ -1,7 +1,10 @@
 package fs_test
 
 import (
+	"errors"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -91,4 +94,25 @@ func TestNewDir_IntegrationWithCleanup(t *testing.T) {
 		_, err := os.Stat(tmpFile.Path())
 		assert.ErrorType(t, err, os.IsNotExist)
 	})
+}
+
+func TestDirFromPath(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", t.Name())
+	assert.NilError(t, err)
+	t.Cleanup(func() {
+		os.RemoveAll(tmpdir)
+	})
+
+	dir := fs.DirFromPath(t, tmpdir, fs.WithFile("newfile", ""))
+
+	_, err = os.Stat(dir.Join("newfile"))
+	assert.NilError(t, err)
+
+	assert.Equal(t, dir.Path(), tmpdir)
+	assert.Equal(t, dir.Join("newfile"), filepath.Join(tmpdir, "newfile"))
+
+	dir.Remove()
+
+	_, err = os.Stat(tmpdir)
+	assert.Assert(t, errors.Is(err, os.ErrNotExist))
 }


### PR DESCRIPTION
On a few occasions I've had the need to create an `fs.Path` for an existing directory. This PR adds `fs.DirFromPath` so that the `PathOp` in this package can be applied to an existing directory.