### PR TITLE
Stop creating directory outside of testdata

### DIFF
--- a/golden/golden.go
+++ b/golden/golden.go
@@ -178,7 +178,7 @@ func update(filename string, actual []byte) error {
 	if !*flagUpdate {
 		return nil
 	}
-	if dir := filepath.Dir(filename); dir != "." {
+	if dir := filepath.Dir(Path(filename)); dir != "." {
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			return err
 		}


### PR DESCRIPTION
This pull request makes it so that updating golden files within sub folders of testdata don't create them outside of testdata.