### PR TITLE
Add support for go 1.18 and higher

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,11 @@ workflows:
             name: go/golang
             tag:  1.17-alpine
       - go/test:
+          name: test-golang-1.18
+          executor:
+            name: go/golang
+            tag:  1.18-alpine
+      - go/test:
           name: test-windows
           executor: windows
           pre-steps:

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -73,13 +73,6 @@ import (
 // BoolOrComparison can be a bool, or cmp.Comparison. See Assert() for usage.
 type BoolOrComparison interface{}
 
-// TestingT is the subset of testing.T used by the assert package.
-type TestingT interface {
-	FailNow()
-	Fail()
-	Log(args ...interface{})
-}
-
 type helperT interface {
 	Helper()
 }

--- a/assert/assert_interface.go
+++ b/assert/assert_interface.go
@@ -1,0 +1,11 @@
+//go:build !go1.18
+// +build !go1.18
+
+package assert
+
+// TestingT is the subset of testing.T used by the assert package.
+type TestingT interface {
+	FailNow()
+	Fail()
+	Log(args ...interface{})
+}

--- a/assert/assert_interface_go118.go
+++ b/assert/assert_interface_go118.go
@@ -1,0 +1,11 @@
+//go:build go1.18
+// +build go1.18
+
+package assert
+
+// TestingT is the subset of testing.T used by the assert package.
+type TestingT interface {
+	FailNow()
+	Fail()
+	Log(args ...any)
+}

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,4 @@ require (
 	golang.org/x/tools v0.1.0
 )
 
-go 1.11
+go 1.18


### PR DESCRIPTION
The `testing.T` Log signature change due to the integration of
generics. This means gotest.tools/assert doesn't work with go 1.18 and
higher.

Fixes #225 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
