### PR TITLE
remove pkg/errors dependency

### DIFF
--- a/assert/cmd/gty-migrate-from-testify/main.go
+++ b/assert/cmd/gty-migrate-from-testify/main.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	"golang.org/x/tools/go/packages"
 	"golang.org/x/tools/imports"
@@ -93,7 +92,7 @@ func run(opts options) error {
 	fset := token.NewFileSet()
 	pkgs, err := loadPackages(opts, fset)
 	if err != nil {
-		return errors.Wrapf(err, "failed to load program")
+		return fmt.Errorf("failed to load program: %w", err)
 	}
 
 	debugf("package count: %d", len(pkgs))
@@ -122,11 +121,11 @@ func run(opts options) error {
 
 			raw, err := formatFile(m)
 			if err != nil {
-				return errors.Wrapf(err, "failed to format %s", filename)
+				return fmt.Errorf("failed to format %s: %w", filename, err)
 			}
 
 			if err := ioutil.WriteFile(absFilename, raw, 0); err != nil {
-				return errors.Wrapf(err, "failed to write file %s", filename)
+				return fmt.Errorf("failed to write file %s: %w", filename, err)
 			}
 		}
 	}

--- a/fs/manifest.go
+++ b/fs/manifest.go
@@ -1,12 +1,12 @@
 package fs
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 )
 
@@ -75,7 +75,7 @@ func manifestFromDir(path string) (Manifest, error) {
 	case err != nil:
 		return Manifest{}, err
 	case !info.IsDir():
-		return Manifest{}, errors.Errorf("path %s must be a directory", path)
+		return Manifest{}, fmt.Errorf("path %s must be a directory", path)
 	}
 
 	directory, err := newDirectory(path, info)

--- a/fs/ops.go
+++ b/fs/ops.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -9,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 )
 
@@ -137,7 +137,7 @@ func WithFiles(files map[string]string) PathOp {
 func FromDir(source string) PathOp {
 	return func(path Path) error {
 		if _, ok := path.(manifestDirectory); ok {
-			return errors.New("use manifest.FromDir")
+			return fmt.Errorf("use manifest.FromDir")
 		}
 		return copyDirectory(source, path.Path())
 	}
@@ -257,7 +257,7 @@ func WithSymlink(path, target string) PathOp {
 func WithHardlink(path, target string) PathOp {
 	return func(root Path) error {
 		if _, ok := root.(manifestDirectory); ok {
-			return errors.New("WithHardlink not implemented for manifests")
+			return fmt.Errorf("WithHardlink not implemented for manifests")
 		}
 		return os.Link(filepath.Join(root.Path(), target), filepath.Join(root.Path(), path))
 	}
@@ -268,7 +268,7 @@ func WithHardlink(path, target string) PathOp {
 func WithTimestamps(atime, mtime time.Time) PathOp {
 	return func(root Path) error {
 		if _, ok := root.(manifestDirectory); ok {
-			return errors.New("WithTimestamp not implemented for manifests")
+			return fmt.Errorf("WithTimestamp not implemented for manifests")
 		}
 		return os.Chtimes(root.Path(), atime, mtime)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.13
 
 require (
 	github.com/google/go-cmp v0.5.5
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.3
 	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4
 	golang.org/x/tools v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/icmd/exitcode.go
+++ b/icmd/exitcode.go
@@ -1,9 +1,9 @@
 package icmd
 
 import (
+	"fmt"
 	"syscall"
 
-	"github.com/pkg/errors"
 	exec "golang.org/x/sys/execabs"
 )
 
@@ -15,7 +15,7 @@ func getExitCode(err error) (int, error) {
 			return procExit.ExitStatus(), nil
 		}
 	}
-	return 0, errors.Wrap(err, "failed to get exit code")
+	return 0, fmt.Errorf("failed to get exit code: %w", err)
 }
 
 func processExitCode(err error) (exitCode int) {

--- a/internal/source/defers.go
+++ b/internal/source/defers.go
@@ -1,10 +1,9 @@
 package source
 
 import (
+	"fmt"
 	"go/ast"
 	"go/token"
-
-	"github.com/pkg/errors"
 )
 
 func scanToDeferLine(fileset *token.FileSet, node ast.Node, lineNum int) ast.Node {
@@ -29,11 +28,11 @@ func guessDefer(node ast.Node) (ast.Node, error) {
 	defers := collectDefers(node)
 	switch len(defers) {
 	case 0:
-		return nil, errors.New("failed to expression in defer")
+		return nil, fmt.Errorf("failed to expression in defer")
 	case 1:
 		return defers[0].Call, nil
 	default:
-		return nil, errors.Errorf(
+		return nil, fmt.Errorf(
 			"ambiguous call expression: multiple (%d) defers in call block",
 			len(defers))
 	}

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -2,6 +2,7 @@ package source // import "gotest.tools/v3/internal/source"
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"go/ast"
 	"go/format"
@@ -11,8 +12,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 const baseStackIndex = 1
@@ -52,7 +51,7 @@ func getNodeAtLine(filename string, lineNum int) (ast.Node, error) {
 	fileset := token.NewFileSet()
 	astFile, err := parser.ParseFile(fileset, filename, nil, parser.AllErrors)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse source file: %s", filename)
+		return nil, fmt.Errorf("failed to parse source file %s: %w", filename, err)
 	}
 
 	if node := scanToLine(fileset, astFile, lineNum); node != nil {
@@ -64,7 +63,7 @@ func getNodeAtLine(filename string, lineNum int) (ast.Node, error) {
 			return node, err
 		}
 	}
-	return nil, errors.Errorf(
+	return nil, fmt.Errorf(
 		"failed to find an expression on line %d in %s", lineNum, filename)
 }
 

--- a/poll/example_test.go
+++ b/poll/example_test.go
@@ -1,9 +1,9 @@
 package poll_test
 
 import (
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"gotest.tools/v3/poll"
 )
 
@@ -19,7 +19,7 @@ func ExampleWaitOn() {
 	check := func(t poll.LogT) poll.Result {
 		actual, err := numOfProcesses()
 		if err != nil {
-			return poll.Error(errors.Wrap(err, "failed to get number of processes"))
+			return poll.Error(fmt.Errorf("failed to get number of processes: %w", err))
 		}
 		if actual == desired {
 			return poll.Success()

--- a/poll/poll_test.go
+++ b/poll/poll_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
 )
@@ -67,7 +66,7 @@ func TestWaitOnWithCheckError(t *testing.T) {
 	fakeT := &fakeT{}
 
 	check := func(t LogT) Result {
-		return Error(errors.New("broke"))
+		return Error(fmt.Errorf("broke"))
 	}
 
 	assert.Assert(t, cmp.Panics(func() { WaitOn(fakeT, check) }))


### PR DESCRIPTION
Use `fmt.Errorf` with `%w` instead, now that the minimum supported Go version is go1.13.