### PR TITLE
Ci update linters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  go: gotest/tools@0.0.13
+  go: gotest/tools@0.0.14
 
 workflows:
   ci:
@@ -49,13 +49,15 @@ executors:
 jobs:
 
   lint:
-    executor: go/golang
+    executor:
+      name: go/golang
+      tag:  1.18-alpine
     steps:
     - checkout
     - go/install-golangci-lint:
-        prefix: v2
-        version: 1.21.0
+        prefix: v1.45.2
+        version: 1.45.2
+    - go/install: {package: git}
     - run:
         name: Lint
-        command: |
-          golangci-lint run -v --concurrency 2
+        command: golangci-lint run -v --concurrency 2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,11 +1,11 @@
 linters-settings:
-  gocyclo:
-    min-complexity: 10
   goconst:
     min-len: 5
     min-occurrences: 10
   lll:
     line-length: 100
+  maintidx:
+    under: 40
 
 issues:
   exclude-use-default: false
@@ -15,7 +15,7 @@ issues:
     - text: 'always receives'
       linters: [unparam]
     - path: _test\.go
-      linters: [errcheck, staticcheck, lll]
+      linters: [errcheck, staticcheck, lll, maintidx]
     - path: internal/difflib/difflib\.go
       text: .
     - text: 'return value of .*Close` is not checked'
@@ -36,9 +36,10 @@ linters:
     - depguard
     - dogsled
     - errcheck
+    - errorlint
+    - exportloopref
     - gocognit
     - goconst
-    - gocyclo
     - gofmt
     - goimports
     - golint
@@ -47,8 +48,13 @@ linters:
     - ineffassign
     - interfacer
     - lll
+    - maintidx
     - misspell
     - nakedret
+    - nestif
+    - nilerr
+    - nilnil
+    - nolintlint
     - prealloc
     - staticcheck
     - structcheck
@@ -58,4 +64,5 @@ linters:
     - unparam
     - unused
     - varcheck
+    - wastedassign
     - whitespace

--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -337,7 +337,6 @@ func expectFailNowed(t testingT, fakeT *fakeTestingT, expected string) {
 	}
 }
 
-// nolint: unparam
 func expectFailed(t testingT, fakeT *fakeTestingT, expected string) {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()

--- a/assert/cmd/gty-migrate-from-testify/main.go
+++ b/assert/cmd/gty-migrate-from-testify/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"go/ast"
 	"go/format"
@@ -78,7 +79,7 @@ func handleExitError(name string, err error) {
 	switch {
 	case err == nil:
 		return
-	case err == pflag.ErrHelp:
+	case errors.Is(err, pflag.ErrHelp):
 		os.Exit(0)
 	default:
 		log.Println(name + ": Error: " + err.Error())

--- a/assert/cmd/gty-migrate-from-testify/migrate.go
+++ b/assert/cmd/gty-migrate-from-testify/migrate.go
@@ -141,7 +141,7 @@ func convertTestifySingleArgCall(tcall call) ast.Node {
 	}
 }
 
-// nolint: gocyclo
+// nolint: maintidx
 func convertTestifyAssertion(tcall call, migration migration) ast.Node {
 	imports := migration.importNames
 

--- a/assert/cmp/compare.go
+++ b/assert/cmp/compare.go
@@ -166,7 +166,7 @@ func Contains(collection interface{}, item interface{}) Comparison {
 	return func() Result {
 		colValue := reflect.ValueOf(collection)
 		if !colValue.IsValid() {
-			return ResultFailure(fmt.Sprintf("nil does not contain items"))
+			return ResultFailure("nil does not contain items")
 		}
 		msg := fmt.Sprintf("%v does not contain %v", collection, item)
 
@@ -248,6 +248,7 @@ type causer interface {
 }
 
 func formatErrorMessage(err error) string {
+	// nolint: errorlint // unwrapping is not appropriate here
 	if _, ok := err.(causer); ok {
 		return fmt.Sprintf("%q\n%+v", err, err)
 	}
@@ -308,7 +309,7 @@ func ErrorType(err error, expected interface{}) Comparison {
 			}
 			return cmpErrorTypeEqualType(err, expectedType)
 		case nil:
-			return ResultFailure(fmt.Sprintf("invalid type for expected: nil"))
+			return ResultFailure("invalid type for expected: nil")
 		}
 
 		expectedType := reflect.TypeOf(expected)

--- a/assert/cmp/compare_test.go
+++ b/assert/cmp/compare_test.go
@@ -441,7 +441,6 @@ func assertFailureHasPrefix(t testingT, res Result, prefix string) {
 	}
 }
 
-// nolint: unparam
 func assertFailureTemplate(t testingT, res Result, args []ast.Expr, expected string) {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()

--- a/fs/report.go
+++ b/fs/report.go
@@ -72,7 +72,6 @@ func removeCarriageReturn(in []byte) []byte {
 	return bytes.Replace(in, []byte("\r\n"), []byte("\n"), -1)
 }
 
-// nolint: gocyclo
 func eqFile(x, y *file) []problem {
 	p := eqResource(x.resource, y.resource)
 
@@ -159,7 +158,7 @@ func eqSymlink(x, y *symlink) []problem {
 
 func eqDirectory(path string, x, y *directory) []failure {
 	p := eqResource(x.resource, y.resource)
-	var f []failure // nolint: prealloc
+	var f []failure
 	matchedFiles := make(map[string]bool)
 
 	for _, name := range sortedKeys(x.items) {

--- a/golden/golden_test.go
+++ b/golden/golden_test.go
@@ -203,7 +203,7 @@ func setupGoldenFileWithDir(t *testing.T, dirname, content string) (string, func
 	_ = os.MkdirAll(filepath.Join("testdata", dirname), 0755)
 	f, err := ioutil.TempFile(dirpath, t.Name()+"-")
 	assert.NilError(t, err, "fail to create test golden file")
-	defer f.Close() // nolint: errcheck
+	defer f.Close()
 
 	_, err = f.Write([]byte(content))
 	assert.NilError(t, err)
@@ -218,7 +218,7 @@ func setupGoldenFile(t *testing.T, content string) (string, func()) {
 	_ = os.Mkdir("testdata", 0755)
 	f, err := ioutil.TempFile("testdata", t.Name()+"-")
 	assert.NilError(t, err, "fail to create test golden file")
-	defer f.Close() // nolint: errcheck
+	defer f.Close()
 
 	_, err = f.Write([]byte(content))
 	assert.NilError(t, err)

--- a/icmd/command.go
+++ b/icmd/command.go
@@ -77,7 +77,6 @@ func (r *Result) Compare(exp Expected) error {
 	return r.match(exp)
 }
 
-// nolint: gocyclo
 func (r *Result) match(exp Expected) error {
 	errors := []string{}
 	add := func(format string, args ...interface{}) {

--- a/icmd/exitcode.go
+++ b/icmd/exitcode.go
@@ -1,32 +1,24 @@
 package icmd
 
 import (
-	"fmt"
-	"syscall"
+	"errors"
 
 	exec "golang.org/x/sys/execabs"
 )
 
-// getExitCode returns the ExitStatus of a process from the error returned by
-// exec.Run(). If the exit status could not be parsed an error is returned.
-func getExitCode(err error) (int, error) {
-	if exiterr, ok := err.(*exec.ExitError); ok {
-		if procExit, ok := exiterr.Sys().(syscall.WaitStatus); ok {
-			return procExit.ExitStatus(), nil
-		}
-	}
-	return 0, fmt.Errorf("failed to get exit code: %w", err)
-}
-
-func processExitCode(err error) (exitCode int) {
+func processExitCode(err error) int {
 	if err == nil {
 		return 0
 	}
-	exitCode, exiterr := getExitCode(err)
-	if exiterr != nil {
-		// TODO: Fix this so we check the error's text.
-		// we've failed to retrieve exit code, so we set it to 127
-		return 127
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		if exitErr.ProcessState == nil {
+			return 0
+		}
+		if code := exitErr.ProcessState.ExitCode(); code != -1 {
+			return code
+		}
 	}
-	return exitCode
+	return 127
 }

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -23,7 +23,6 @@ type helperT interface {
 const failureMessage = "assertion failed: "
 
 // Eval the comparison and print a failure messages if the comparison has failed.
-// nolint: gocyclo
 func Eval(
 	t LogT,
 	argSelector argSelector,


### PR DESCRIPTION
update golangci-lint version
use some new linters
remove some unnecessary nolint comments
fix some lint errors 
use thew new (in go1.12) ProcessState.ExitCode to get the exit code from the error