### PR TITLE
golden: accept -update for updating files

### DIFF
--- a/golden/golden.go
+++ b/golden/golden.go
@@ -20,7 +20,12 @@ import (
 	"gotest.tools/v3/internal/format"
 )
 
-var flagUpdate = flag.Bool("test.update-golden", false, "update golden file")
+var flagUpdate bool
+
+func init() {
+	flag.BoolVar(&flagUpdate, "update", false, "update golden files")
+	flag.BoolVar(&flagUpdate, "test.update-golden", false, "deprecated flag")
+}
 
 type helperT interface {
 	Helper()
@@ -41,7 +46,7 @@ var NormalizeCRLFToLF = os.Getenv("GOTESTTOOLS_GOLDEN_NormalizeCRLFToLF") != "fa
 
 // FlagUpdate returns true when the -test.update-golden flag has been set.
 func FlagUpdate() bool {
-	return *flagUpdate
+	return flagUpdate
 }
 
 // Open opens the file in ./testdata
@@ -175,7 +180,7 @@ func compare(actual []byte, filename string) (cmp.Result, []byte) {
 }
 
 func update(filename string, actual []byte) error {
-	if !*flagUpdate {
+	if !flagUpdate {
 		return nil
 	}
 	if dir := filepath.Dir(Path(filename)); dir != "." {

--- a/golden/golden_test.go
+++ b/golden/golden_test.go
@@ -96,8 +96,7 @@ func TestGoldenAssertInvalidContent(t *testing.T) {
 }
 
 func TestGoldenAssertInvalidContentUpdate(t *testing.T) {
-	undo := setUpdateFlag()
-	defer undo()
+	setUpdateFlag(t)
 	filename, clean := setupGoldenFile(t, "content")
 	defer clean()
 
@@ -132,8 +131,7 @@ func TestGoldenAssertInDir(t *testing.T) {
 func TestGoldenAssertInDir_UpdateGolden(t *testing.T) {
 	filename, clean := setupGoldenFileWithDir(t, "testdatasubdir", "foo")
 	defer clean()
-	unsetUpdateFlag := setUpdateFlag()
-	defer unsetUpdateFlag()
+	setUpdateFlag(t)
 
 	fakeT := new(fakeT)
 
@@ -167,8 +165,7 @@ func TestAssert_WithCarriageReturnInActual(t *testing.T) {
 func TestAssert_WithCarriageReturnInActual_UpdateGolden(t *testing.T) {
 	filename, clean := setupGoldenFile(t, "")
 	defer clean()
-	unsetUpdateFlag := setUpdateFlag()
-	defer unsetUpdateFlag()
+	unsetUpdateFlag := setUpdateFlag(t)
 
 	fakeT := new(fakeT)
 	Assert(fakeT, "a\rfoo\r\nbar\r\n", filename)
@@ -192,10 +189,14 @@ func TestGoldenAssertBytes(t *testing.T) {
 	assert.Assert(t, !fakeT.Failed)
 }
 
-func setUpdateFlag() func() {
-	oldFlagUpdate := *flagUpdate
-	*flagUpdate = true
-	return func() { *flagUpdate = oldFlagUpdate }
+func setUpdateFlag(t *testing.T) func() {
+	orig := flagUpdate
+	flagUpdate = true
+	undo := func() {
+		flagUpdate = orig
+	}
+	t.Cleanup(undo)
+	return undo
 }
 
 func setupGoldenFileWithDir(t *testing.T, dirname, content string) (string, func()) {
@@ -260,14 +261,12 @@ func TestBytesFailure(t *testing.T) {
 
 func TestFlagUpdate(t *testing.T) {
 	assert.Assert(t, !FlagUpdate())
-	undo := setUpdateFlag()
-	defer undo()
+	setUpdateFlag(t)
 	assert.Assert(t, FlagUpdate())
 }
 
 func TestUpdate_CreatesPathsAndFile(t *testing.T) {
-	undo := setUpdateFlag()
-	defer undo()
+	setUpdateFlag(t)
 
 	dir := fs.NewDir(t, t.Name())
 


### PR DESCRIPTION
The `-test.update-golden` flag is long enough that it can be a challenge for people to remember, especially when golden files are not updated frequently.  I've seen other implementations of this pattern use just the `-update` flag, which was easier to remember.

This PR keeps support for the existing `-test.update-golden` flag, but also adds `-update` as an option for updating golden files.

In the future there could be other auto-update operations that could make use of this same flag.