### PR TITLE
Update README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,12 @@ module paths pin to version `v2.3.0`.
 
 ## Related
 
-* [gotest.tools/gotestsum](https://github.com/gotestyourself/gotestsum) - go test runner with custom output
-* [maxbrunsfeld/counterfeiter](https://github.com/maxbrunsfeld/counterfeiter) - generate fakes for interfaces
-* [jonboulle/clockwork](https://github.com/jonboulle/clockwork) - a fake clock for testing code that uses `time`
+* [gotest.tools/gotestsum](https://github.com/gotestyourself/gotestsum) -
+  go test runner with custom output
+* [go testing patterns](https://github.com/gotestyourself/gotest.tools/wiki/Go-Testing-Patterns) -
+  zero-depedency patterns for organizing test cases
+* [test doubles and patching](https://github.com/gotestyourself/gotest.tools/wiki/Test-Doubles-And-Patching) -
+  zero-depdency test doubles (fakes, spies, stubs, and mocks) and monkey patching patterns
 
 ## Contributing
 


### PR DESCRIPTION
I have not made much use of a couple of the links in the README. Lately I've found that applying some of these patterns is much easier than using a library. 

This PR updates the README to point at the wiki pages that describe these patterns.