### PR TITLE
Test against Go1.19, and remove a dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,6 @@ workflows:
     jobs:
       - lint
       - go/test:
-          name: test-golang-1.15
-          executor:
-            name: go/golang
-            tag:  1.15-alpine
-      - go/test:
           name: test-golang-1.16
           executor:
             name: go/golang
@@ -27,6 +22,11 @@ workflows:
           executor:
             name: go/golang
             tag:  1.18-alpine
+      - go/test:
+          name: test-golang-1.19
+          executor:
+            name: go/golang
+            tag:  1.19-alpine
       - go/test:
           name: test-windows
           executor: windows
@@ -51,7 +51,7 @@ jobs:
   lint:
     executor:
       name: go/golang
-      tag:  1.18-alpine
+      tag:  1.19-alpine
     steps:
     - checkout
     - go/install-golangci-lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,8 +55,8 @@ jobs:
     steps:
     - checkout
     - go/install-golangci-lint:
-        prefix: v1.45.2
-        version: 1.45.2
+        prefix: v1.48.0
+        version: 1.48.0
     - go/install: {package: git}
     - run:
         name: Lint

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -1,7 +1,8 @@
-/*Package assert provides assertions for comparing expected values to actual
+/*
+Package assert provides assertions for comparing expected values to actual
 values in tests. When an assertion fails a helpful error message is printed.
 
-Example usage
+# Example usage
 
 All the assertions in this package use testing.T.Helper to mark themselves as
 test helpers. This allows the testing package to print the filename and line
@@ -64,7 +65,7 @@ message is omitted from these examples for brevity.
 	assert.Assert(t, ref != nil) // use Assert for NotNil
 	// assertion failed: ref is nil
 
-Assert and Check
+# Assert and Check
 
 Assert and Check are very similar, they both accept a Comparison, and fail
 the test when the comparison fails. The one difference is that Assert uses
@@ -76,20 +77,18 @@ Like testing.T.FailNow, Assert must be called from the goroutine running the tes
 not from other goroutines created during the test. Check is safe to use from any
 goroutine.
 
-Comparisons
+# Comparisons
 
 Package http://pkg.go.dev/gotest.tools/v3/assert/cmp provides
 many common comparisons. Additional comparisons can be written to compare
 values in other ways. See the example Assert (CustomComparison).
 
-Automated migration from testify
+# Automated migration from testify
 
 gty-migrate-from-testify is a command which translates Go source code from
 testify assertions to the assertions provided by this package.
 
 See http://pkg.go.dev/gotest.tools/v3/assert/cmd/gty-migrate-from-testify.
-
-
 */
 package assert // import "gotest.tools/v3/assert"
 
@@ -119,19 +118,18 @@ type helperT interface {
 //
 // The comparison argument may be one of three types:
 //
-//   bool
-//     True is success. False is a failure. The failure message will contain
-//     the literal source code of the expression.
+//	bool
+//	  True is success. False is a failure. The failure message will contain
+//	  the literal source code of the expression.
 //
-//   cmp.Comparison
-//     Uses cmp.Result.Success() to check for success or failure.
-//     The comparison is responsible for producing a helpful failure message.
-//     http://pkg.go.dev/gotest.tools/v3/assert/cmp provides many common comparisons.
+//	cmp.Comparison
+//	  Uses cmp.Result.Success() to check for success or failure.
+//	  The comparison is responsible for producing a helpful failure message.
+//	  http://pkg.go.dev/gotest.tools/v3/assert/cmp provides many common comparisons.
 //
-//   error
-//     A nil value is considered success, and a non-nil error is a failure.
-//     The return value of error.Error is used as the failure message.
-//
+//	error
+//	  A nil value is considered success, and a non-nil error is a failure.
+//	  The return value of error.Error is used as the failure message.
 //
 // Extra details can be added to the failure message using msgAndArgs. msgAndArgs
 // may be either a single string, or a format string and args that will be
@@ -187,8 +185,8 @@ func NilError(t TestingT, err error, msgAndArgs ...interface{}) {
 // x and y as part of the failure message to identify the actual and expected
 // values.
 //
-//   assert.Equal(t, actual, expected)
-//   // main_test.go:41: assertion failed: 1 (actual int) != 21 (expected int32)
+//	assert.Equal(t, actual, expected)
+//	// main_test.go:41: assertion failed: 1 (actual int) != 21 (expected int32)
 //
 // If either x or y are a multi-line string the failure message will include a
 // unified diff of the two values. If the values only differ by whitespace
@@ -269,19 +267,19 @@ func ErrorContains(t TestingT, err error, substring string, msgAndArgs ...interf
 //
 // Expected can be one of:
 //
-//   func(error) bool
-//     The function should return true if the error is the expected type.
+//	func(error) bool
+//	  The function should return true if the error is the expected type.
 //
-//   struct{} or *struct{}
-//     A struct or a pointer to a struct. The assertion fails if the error is
-//     not of the same type.
+//	struct{} or *struct{}
+//	  A struct or a pointer to a struct. The assertion fails if the error is
+//	  not of the same type.
 //
-//   *interface{}
-//     A pointer to an interface type. The assertion fails if err does not
-//     implement the interface.
+//	*interface{}
+//	  A pointer to an interface type. The assertion fails if err does not
+//	  implement the interface.
 //
-//   reflect.Type
-//     The assertion fails if err does not implement the reflect.Type.
+//	reflect.Type
+//	  The assertion fails if err does not implement the reflect.Type.
 //
 // ErrorType uses t.FailNow to fail the test. Like t.FailNow, ErrorType
 // must be called from the goroutine running the test function, not from other

--- a/assert/cmd/gty-migrate-from-testify/call.go
+++ b/assert/cmd/gty-migrate-from-testify/call.go
@@ -22,7 +22,7 @@ type call struct {
 
 func (c call) String() string {
 	buf := new(bytes.Buffer)
-	// nolint: errcheck
+	//nolint: errcheck
 	format.Node(buf, token.NewFileSet(), c.expr)
 	return buf.String()
 }

--- a/assert/cmd/gty-migrate-from-testify/doc.go
+++ b/assert/cmd/gty-migrate-from-testify/doc.go
@@ -1,5 +1,4 @@
 /*
-
 Command gty-migrate-from-testify migrates packages from
 testify/assert and testify/require to gotest.tools/v3/assert.
 
@@ -11,12 +10,10 @@ Usage:
 
 See --help for full usage.
 
-
 To run on all packages (including external test packages) use:
 
 	go list \
 		-f '{{.ImportPath}} {{if .XTestGoFiles}}{{"\n"}}{{.ImportPath}}_test{{end}}' \
 		./... | xargs gty-migrate-from-testify
-
 */
 package main

--- a/assert/cmd/gty-migrate-from-testify/flags.go
+++ b/assert/cmd/gty-migrate-from-testify/flags.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"encoding/csv"
+	"strings"
+)
+
+type stringSliceValue []string
+
+func (s stringSliceValue) String() string {
+	return strings.Join(s, ", ")
+}
+
+func (s *stringSliceValue) Set(raw string) error {
+	if raw == "" {
+		return nil
+	}
+	v, err := csv.NewReader(strings.NewReader(raw)).Read()
+	if err != nil {
+		return err
+	}
+	*s = append(*s, v...)
+	return nil
+}

--- a/assert/cmd/gty-migrate-from-testify/migrate.go
+++ b/assert/cmd/gty-migrate-from-testify/migrate.go
@@ -141,8 +141,7 @@ func convertTestifySingleArgCall(tcall call) ast.Node {
 	}
 }
 
-// nolint: maintidx
-func convertTestifyAssertion(tcall call, migration migration) ast.Node {
+func convertTestifyAssertion(tcall call, migration migration) ast.Node { //nolint:maintidx
 	imports := migration.importNames
 
 	switch tcall.selExpr.Sel.Name {

--- a/assert/cmp/compare.go
+++ b/assert/cmp/compare.go
@@ -68,9 +68,10 @@ type RegexOrPattern interface{}
 // Regexp succeeds if value v matches regular expression re.
 //
 // Example:
-//   assert.Assert(t, cmp.Regexp("^[0-9a-f]{32}$", str))
-//   r := regexp.MustCompile("^[0-9a-f]{32}$")
-//   assert.Assert(t, cmp.Regexp(r, str))
+//
+//	assert.Assert(t, cmp.Regexp("^[0-9a-f]{32}$", str))
+//	r := regexp.MustCompile("^[0-9a-f]{32}$")
+//	assert.Assert(t, cmp.Regexp(r, str))
 func Regexp(re RegexOrPattern, v string) Comparison {
 	match := func(re *regexp.Regexp) Result {
 		return toResult(
@@ -248,7 +249,7 @@ type causer interface {
 }
 
 func formatErrorMessage(err error) string {
-	// nolint: errorlint // unwrapping is not appropriate here
+	//nolint: errorlint // unwrapping is not appropriate here
 	if _, ok := err.(causer); ok {
 		return fmt.Sprintf("%q\n%+v", err, err)
 	}
@@ -288,15 +289,23 @@ func isNil(obj interface{}, msgFunc func(reflect.Value) string) Comparison {
 // ErrorType succeeds if err is not nil and is of the expected type.
 //
 // Expected can be one of:
-//   func(error) bool
+//
+//	func(error) bool
+//
 // Function should return true if the error is the expected type.
-//   type struct{}, type &struct{}
+//
+//	type struct{}, type &struct{}
+//
 // A struct or a pointer to a struct.
 // Fails if the error is not of the same type as expected.
-//   type &interface{}
+//
+//	type &interface{}
+//
 // A pointer to an interface type.
 // Fails if err does not implement the interface.
-//   reflect.Type
+//
+//	reflect.Type
+//
 // Fails if err does not implement the reflect.Type
 func ErrorType(err error, expected interface{}) Comparison {
 	return func() Result {

--- a/env/env.go
+++ b/env/env.go
@@ -1,4 +1,5 @@
-/*Package env provides functions to test code that read environment variables
+/*
+Package env provides functions to test code that read environment variables
 or the current working directory.
 */
 package env // import "gotest.tools/v3/env"

--- a/fs/file.go
+++ b/fs/file.go
@@ -1,4 +1,5 @@
-/*Package fs provides tools for creating temporary files, and testing the
+/*
+Package fs provides tools for creating temporary files, and testing the
 contents and structure of a directory.
 */
 package fs // import "gotest.tools/v3/fs"
@@ -71,7 +72,7 @@ func (f *File) Path() string {
 
 // Remove the file
 func (f *File) Remove() {
-	// nolint: errcheck
+	//nolint: errcheck
 	os.Remove(f.path)
 }
 
@@ -105,7 +106,7 @@ func (d *Dir) Path() string {
 
 // Remove the directory
 func (d *Dir) Remove() {
-	// nolint: errcheck
+	//nolint: errcheck
 	os.RemoveAll(d.path)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,5 @@ go 1.13
 
 require (
 	github.com/google/go-cmp v0.5.5
-	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4
 	golang.org/x/tools v0.1.0
 )

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.13
 
 require (
 	github.com/google/go-cmp v0.5.5
-	github.com/spf13/pflag v1.0.3
 	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4
 	golang.org/x/tools v0.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
-github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/golden/golden.go
+++ b/golden/golden.go
@@ -1,4 +1,5 @@
-/*Package golden provides tools for comparing large mutli-line strings.
+/*
+Package golden provides tools for comparing large mutli-line strings.
 
 Golden files are files in the ./testdata/ subdirectory of the package under test.
 Golden files can be automatically updated to match new values by running

--- a/icmd/command.go
+++ b/icmd/command.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"strings"
 	"sync"
 	"time"
 
-	exec "golang.org/x/sys/execabs"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
 )

--- a/icmd/command_test.go
+++ b/icmd/command_test.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
 
-	exec "golang.org/x/sys/execabs"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/fs"
 	"gotest.tools/v3/internal/maint"

--- a/icmd/exitcode.go
+++ b/icmd/exitcode.go
@@ -2,8 +2,7 @@ package icmd
 
 import (
 	"errors"
-
-	exec "golang.org/x/sys/execabs"
+	"os/exec"
 )
 
 func processExitCode(err error) int {

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -1,4 +1,5 @@
-/*Package cleanup handles migration to and support for the Go 1.14+
+/*
+Package cleanup handles migration to and support for the Go 1.14+
 testing.TB.Cleanup() function.
 */
 package cleanup

--- a/pkg.go
+++ b/pkg.go
@@ -1,4 +1,5 @@
-/*Package gotesttools is a collection of packages to augment `testing` and
+/*
+Package gotesttools is a collection of packages to augment `testing` and
 support common patterns.
 */
 package gotesttools // import "gotest.tools/v3"

--- a/skip/skip.go
+++ b/skip/skip.go
@@ -1,4 +1,5 @@
-/*Package skip provides functions for skipping a test and printing the source code
+/*
+Package skip provides functions for skipping a test and printing the source code
 of the condition used to skip the test.
 */
 package skip // import "gotest.tools/v3/skip"

--- a/x/doc.go
+++ b/x/doc.go
@@ -1,4 +1,5 @@
-/*Package x is a namespace for experimental packages. Packages under x have looser
+/*
+Package x is a namespace for experimental packages. Packages under x have looser
 compatibility requirements. Packages in this namespace may contain backwards
 incompatible changes within the same major version.
 */

--- a/x/subtest/context.go
+++ b/x/subtest/context.go
@@ -1,9 +1,10 @@
-/*Package subtest provides a TestContext to subtests which handles cleanup, and
+/*
+Package subtest provides a TestContext to subtests which handles cleanup, and
 provides a testing.TB, and context.Context.
 
 This package was inspired by github.com/frankban/quicktest.
 
-DEPRECATED
+# DEPRECATED
 
 With the addition of T.Cleanup() in go1.14 this package provides very
 little value. A context.Context can be managed by tests that need it with


### PR DESCRIPTION
`gofmt` changed in go1.19, so this PR includes the new formatting applied by `gofmt`.