### PR TITLE
assert: allow updating expected vars/consts inside functions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,7 @@ linters-settings:
   lll:
     line-length: 100
   maintidx:
-    under: 40
+    under: 35
 
 issues:
   exclude-use-default: false

--- a/assert/cmd/gty-migrate-from-testify/migrate.go
+++ b/assert/cmd/gty-migrate-from-testify/migrate.go
@@ -141,7 +141,7 @@ func convertTestifySingleArgCall(tcall call) ast.Node {
 	}
 }
 
-func convertTestifyAssertion(tcall call, migration migration) ast.Node { //nolint:maintidx
+func convertTestifyAssertion(tcall call, migration migration) ast.Node {
 	imports := migration.importNames
 
 	switch tcall.selExpr.Sel.Name {

--- a/internal/source/update.go
+++ b/internal/source/update.go
@@ -54,7 +54,7 @@ func UpdateExpectedValue(stackIndex int, x, y interface{}) error {
 		return ErrNotFound
 	}
 
-	argIndex, ident := getVarNameForExpectedValueArg(expr)
+	argIndex, ident := getIdentForExpectedValueArg(expr)
 	if argIndex < 0 || ident == nil {
 		debug("no arguments started with the word 'expected': %v",
 			debugFormatNode{Node: &ast.CallExpr{Args: expr}})
@@ -138,7 +138,7 @@ func UpdateVariable(
 	return nil
 }
 
-func getVarNameForExpectedValueArg(expr []ast.Expr) (int, *ast.Ident) {
+func getIdentForExpectedValueArg(expr []ast.Expr) (int, *ast.Ident) {
 	for i := 1; i < 3; i++ {
 		switch e := expr[i].(type) {
 		case *ast.Ident:

--- a/internal/source/update.go
+++ b/internal/source/update.go
@@ -54,8 +54,8 @@ func UpdateExpectedValue(stackIndex int, x, y interface{}) error {
 		return ErrNotFound
 	}
 
-	argIndex, varName := getVarNameForExpectedValueArg(expr)
-	if argIndex < 0 || varName == "" {
+	argIndex, ident := getVarNameForExpectedValueArg(expr)
+	if argIndex < 0 || ident == nil {
 		debug("no arguments started with the word 'expected': %v",
 			debugFormatNode{Node: &ast.CallExpr{Args: expr}})
 		return ErrNotFound
@@ -71,7 +71,7 @@ func UpdateExpectedValue(stackIndex int, x, y interface{}) error {
 		debug("value must be type string, got %T", value)
 		return ErrNotFound
 	}
-	return UpdateVariable(filename, fileset, astFile, varName, strValue)
+	return UpdateVariable(filename, fileset, astFile, ident, strValue)
 }
 
 // UpdateVariable writes to filename the contents of astFile with the value of
@@ -80,10 +80,10 @@ func UpdateVariable(
 	filename string,
 	fileset *token.FileSet,
 	astFile *ast.File,
-	varName string,
+	ident *ast.Ident,
 	value string,
 ) error {
-	obj := astFile.Scope.Objects[varName]
+	obj := ident.Obj
 	if obj == nil {
 		return ErrNotFound
 	}
@@ -92,19 +92,32 @@ func UpdateVariable(
 		return ErrNotFound
 	}
 
-	spec, ok := obj.Decl.(*ast.ValueSpec)
-	if !ok {
+	switch decl := obj.Decl.(type) {
+	case *ast.ValueSpec:
+		if len(decl.Names) != 1 {
+			debug("more than one name in ast.ValueSpec")
+			return ErrNotFound
+		}
+
+		decl.Values[0] = &ast.BasicLit{
+			Kind:  token.STRING,
+			Value: "`" + value + "`",
+		}
+
+	case *ast.AssignStmt:
+		if len(decl.Lhs) != 1 {
+			debug("more than one name in ast.AssignStmt")
+			return ErrNotFound
+		}
+
+		decl.Rhs[0] = &ast.BasicLit{
+			Kind:  token.STRING,
+			Value: "`" + value + "`",
+		}
+
+	default:
 		debug("can only update *ast.ValueSpec, found %T", obj.Decl)
 		return ErrNotFound
-	}
-	if len(spec.Names) != 1 {
-		debug("more than one name in ast.ValueSpec")
-		return ErrNotFound
-	}
-
-	spec.Values[0] = &ast.BasicLit{
-		Kind:  token.STRING,
-		Value: "`" + value + "`",
 	}
 
 	var buf bytes.Buffer
@@ -125,14 +138,14 @@ func UpdateVariable(
 	return nil
 }
 
-func getVarNameForExpectedValueArg(expr []ast.Expr) (int, string) {
+func getVarNameForExpectedValueArg(expr []ast.Expr) (int, *ast.Ident) {
 	for i := 1; i < 3; i++ {
 		switch e := expr[i].(type) {
 		case *ast.Ident:
 			if strings.HasPrefix(strings.ToLower(e.Name), "expected") {
-				return i, e.Name
+				return i, e
 			}
 		}
 	}
-	return -1, ""
+	return -1, nil
 }


### PR DESCRIPTION
Hi, thank you for such useful library. I was reading source and found `-update` flag to update the test code itself with "expectedXXX"-named variables. This was what I just wanted. Cool!

Currently the source-update functionality only supports toplevel names. This PR changes this behavior to rewrite vars/consts which resides deeper scope.