### PR TITLE
Deprecate assert.ErrorType

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -262,8 +262,7 @@ func ErrorContains(t TestingT, err error, substring string, msgAndArgs ...interf
 }
 
 // ErrorType fails the test if err is nil, or err is not the expected type.
-// Most new code should use ErrorIs instead. ErrorType may be deprecated in the
-// future.
+// New code should use ErrorIs instead.
 //
 // Expected can be one of:
 //
@@ -285,6 +284,8 @@ func ErrorContains(t TestingT, err error, substring string, msgAndArgs ...interf
 // must be called from the goroutine running the test function, not from other
 // goroutines created during the test. Use Check with cmp.ErrorType from other
 // goroutines.
+//
+// Deprecated: Use ErrorIs
 func ErrorType(t TestingT, err error, expected interface{}, msgAndArgs ...interface{}) {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()

--- a/assert/cmp/compare.go
+++ b/assert/cmp/compare.go
@@ -306,7 +306,9 @@ func isNil(obj interface{}, msgFunc func(reflect.Value) string) Comparison {
 //
 //	reflect.Type
 //
-// Fails if err does not implement the reflect.Type
+// Fails if err does not implement the reflect.Type.
+//
+// Deprecated: Use ErrorIs
 func ErrorType(err error, expected interface{}) Comparison {
 	return func() Result {
 		switch expectedType := expected.(type) {

--- a/fs/file_test.go
+++ b/fs/file_test.go
@@ -51,7 +51,7 @@ func TestNewFile(t *testing.T) {
 
 		tmpFile.Remove()
 		_, err = os.Stat(tmpFile.Path())
-		assert.ErrorType(t, err, os.IsNotExist)
+		assert.ErrorIs(t, err, os.ErrNotExist)
 	})
 
 	t.Run(`with \ in name`, func(t *testing.T) {
@@ -61,7 +61,7 @@ func TestNewFile(t *testing.T) {
 
 		tmpFile.Remove()
 		_, err = os.Stat(tmpFile.Path())
-		assert.ErrorType(t, err, os.IsNotExist)
+		assert.ErrorIs(t, err, os.ErrNotExist)
 	})
 }
 
@@ -76,7 +76,7 @@ func TestNewFile_IntegrationWithCleanup(t *testing.T) {
 
 	t.Run("file has been removed", func(t *testing.T) {
 		_, err := os.Stat(tmpFile.Path())
-		assert.ErrorType(t, err, os.IsNotExist)
+		assert.ErrorIs(t, err, os.ErrNotExist)
 	})
 }
 
@@ -91,7 +91,7 @@ func TestNewDir_IntegrationWithCleanup(t *testing.T) {
 
 	t.Run("dir has been removed", func(t *testing.T) {
 		_, err := os.Stat(tmpFile.Path())
-		assert.ErrorType(t, err, os.IsNotExist)
+		assert.ErrorIs(t, err, os.ErrNotExist)
 	})
 }
 


### PR DESCRIPTION
ErrorIs has replaced it entirely.