### PR TITLE
assert/cmd/gty-migrate-from-testify: fix TestRun by adding "go get" commands

### DIFF
--- a/assert/cmd/gty-migrate-from-testify/main_test.go
+++ b/assert/cmd/gty-migrate-from-testify/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -11,6 +12,14 @@ import (
 	"gotest.tools/v3/golden"
 )
 
+func goGet(t *testing.T, pkg string) {
+	t.Log("go get", pkg)
+	cmd := exec.Command("go", "get", pkg)
+	if err := cmd.Run(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestRun(t *testing.T) {
 	setupLogging(&options{})
 	dir := fs.NewDir(t, "test-run",
@@ -19,6 +28,13 @@ func TestRun(t *testing.T) {
 
 	defer env.Patch(t, "GO111MODULE", "off")()
 	defer env.Patch(t, "GOPATH", dir.Path())()
+
+	// Fetch dependencies in GOPATH mode
+	// Check list in testdata/full/some_test.go
+	goGet(t, "github.com/go-check/check")
+	goGet(t, "github.com/stretchr/testify/assert")
+	goGet(t, "github.com/stretchr/testify/require")
+
 	err := run(options{
 		pkgs:             []string{"example.com/example"},
 		showLoaderErrors: true,


### PR DESCRIPTION
The test TestRun of the gty-migrate-from-testify tool apparently needs to have the original packages available to run. So let's install them ("go get" in GOPATH mode, in a temporary directory) before running the migration test.

Here are example of the test failures that this patch fixes:
* https://app.circleci.com/pipelines/github/gotestyourself/gotest.tools/303/workflows/0a211869-a6ad-4bfb-83ff-77322b76edff/jobs/3406?invite=true#step-108-34
* https://app.circleci.com/pipelines/github/gotestyourself/gotest.tools/305/workflows/faa51546-d296-4ea3-ae27-ea55f9fb10f1/jobs/3414?invite=true#step-108-34
* https://app.circleci.com/pipelines/github/gotestyourself/gotest.tools/306/workflows/3771fe06-2f47-4f1a-a055-f8dbad25f720/jobs/3423?invite=true#step-108-34
* https://app.circleci.com/pipelines/github/gotestyourself/gotest.tools/307/workflows/a92c08a1-cc13-40d9-abf9-440b01eb803f/jobs/3427?invite=true#step-108-34