### PR TITLE
Make assert and golden packages compatible with other golden packages

### DIFF
--- a/golden/golden.go
+++ b/golden/golden.go
@@ -6,7 +6,7 @@ Golden files can be automatically updated to match new values by running
 `go test pkgname -update`. To ensure the update is correct
 compare the diff of the old expected value to the new expected value.
 */
-package golden // import "gotest.tools/v3/golden"
+package golden
 
 import (
 	"bytes"
@@ -44,7 +44,7 @@ var NormalizeCRLFToLF = os.Getenv("GOTESTTOOLS_GOLDEN_NormalizeCRLFToLF") != "fa
 
 // FlagUpdate returns true when the -update flag has been set.
 func FlagUpdate() bool {
-	return source.Update
+	return source.IsUpdate()
 }
 
 // Open opens the file in ./testdata
@@ -178,7 +178,7 @@ func compare(actual []byte, filename string) (cmp.Result, []byte) {
 }
 
 func update(filename string, actual []byte) error {
-	if !source.Update {
+	if !source.IsUpdate() {
 		return nil
 	}
 	if dir := filepath.Dir(Path(filename)); dir != "." {

--- a/internal/assert/result.go
+++ b/internal/assert/result.go
@@ -26,7 +26,7 @@ func RunComparison(
 		return true
 	}
 
-	if source.Update {
+	if source.IsUpdate() {
 		if updater, ok := result.(updateExpected); ok {
 			const stackIndex = 3 // Assert/Check, assert, RunComparison
 			err := updater.UpdatedExpected(stackIndex)

--- a/internal/source/update.go
+++ b/internal/source/update.go
@@ -14,12 +14,32 @@ import (
 	"strings"
 )
 
-// Update is set by the -update flag. It indicates the user running the tests
-// would like to update any golden values.
+// IsUpdate is returns true if the -update flag is set. It indicates the user
+// running the tests would like to update any golden values.
+func IsUpdate() bool {
+	if Update {
+		return true
+	}
+	return flag.Lookup("update").Value.(flag.Getter).Get().(bool)
+}
+
+// Update is a shim for testing, and for compatibility with the old -update-golden
+// flag.
 var Update bool
 
 func init() {
-	flag.BoolVar(&Update, "update", false, "update golden values")
+	if f := flag.Lookup("update"); f != nil {
+		getter, ok := f.Value.(flag.Getter)
+		msg := "some other package defined an incompatible -update flag, expected a flag.Bool"
+		if !ok {
+			panic(msg)
+		}
+		if _, ok := getter.Get().(bool); !ok {
+			panic(msg)
+		}
+		return
+	}
+	flag.Bool("update", false, "update golden values")
 }
 
 // ErrNotFound indicates that UpdateExpectedValue failed to find the


### PR DESCRIPTION
Fixes #270 

Lookup the `update` flag, and only define it when it's not defined by another package. This works as long as `gotest.tools/v3` is imported after the other package. Other packages can make themselves compatible with `gotest.tools/v3` by using the same approach.