### PR TITLE
Also remove cr from file

### DIFF
--- a/golden/golden.go
+++ b/golden/golden.go
@@ -40,6 +40,14 @@ type helperT interface {
 // in the environment before running tests.
 //
 // The default value may change in a future major release.
+//
+// This does not affect the contents of the golden files themselves. And depending on the
+// git settings on your system (or in github action platform default like windows), the
+// golden files may contain CRLF line endings.  You can avoid this by setting the
+// .gitattributes file in your repo to use LF line endings for all files, or just the golden files, by
+// adding the following line to your .gitattributes file:
+//
+// * text=auto eol=lf
 var NormalizeCRLFToLF = os.Getenv("GOTESTTOOLS_GOLDEN_NormalizeCRLFToLF") != "false"
 
 // FlagUpdate returns true when the -update flag has been set.

--- a/golden/golden.go
+++ b/golden/golden.go
@@ -44,8 +44,8 @@ type helperT interface {
 // This does not affect the contents of the golden files themselves. And depending on the
 // git settings on your system (or in github action platform default like windows), the
 // golden files may contain CRLF line endings.  You can avoid this by setting the
-// .gitattributes file in your repo to use LF line endings for all files, or just the golden files, by
-// adding the following line to your .gitattributes file:
+// .gitattributes file in your repo to use LF line endings for all files, or just the golden
+// files, by adding the following line to your .gitattributes file:
 //
 // * text=auto eol=lf
 var NormalizeCRLFToLF = os.Getenv("GOTESTTOOLS_GOLDEN_NormalizeCRLFToLF") != "false"


### PR DESCRIPTION
When executing on github actions on a windows platform, it can happen (depending on your .gitattributes setting or lack of settings), that the golden files will also have carriage return.

This PR removes it from the file when reading it.

Another option would be a documentations about adding `.gitattributes` file to the repo with `* text=auto eol=lf`
