### PR TITLE
assert: ensure message is always displayed & fix under bazel

### DIFF
--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -87,19 +87,18 @@ func logFailureFromBool(t LogT, msgAndArgs ...interface{}) {
 	args, err := source.CallExprArgs(stackIndex)
 	if err != nil {
 		t.Log(err.Error())
-		return
 	}
 
+	var msg string
 	const comparisonArgIndex = 1 // Assert(t, comparison)
 	if len(args) <= comparisonArgIndex {
-		t.Log(failureMessage + "but assert failed to find the expression to print")
-		return
-	}
-
-	msg, err := boolFailureMessage(args[comparisonArgIndex])
-	if err != nil {
-		t.Log(err.Error())
-		msg = "expression is false"
+		msg = "but assert failed to find the expression to print"
+	} else {
+		msg, err = boolFailureMessage(args[comparisonArgIndex])
+		if err != nil {
+			t.Log(err.Error())
+			msg = "expression is false"
+		}
 	}
 
 	t.Log(format.WithCustomMessage(failureMessage+msg, msgAndArgs...))

--- a/internal/source/bazel.go
+++ b/internal/source/bazel.go
@@ -1,0 +1,51 @@
+package source
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// These Bazel env vars are documented here:
+// https://bazel.build/reference/test-encyclopedia
+
+// Signifies test executable is being driven by `bazel test`.
+//
+// Due to Bazel's compilation and sandboxing strategy,
+// some care is required to handle resolving the original *.go source file.
+var inBazelTest = os.Getenv("BAZEL_TEST") == "1"
+
+// The name of the target being tested (ex: //some_package:some_package_test)
+var bazelTestTarget = os.Getenv("TEST_TARGET")
+
+// Absolute path to the base of the runfiles tree
+var bazelTestSrcdir = os.Getenv("TEST_SRCDIR")
+
+// The local repository's workspace name (ex: __main__)
+var bazelTestWorkspace = os.Getenv("TEST_WORKSPACE")
+
+func bazelSourcePath(filename string) (string, error) {
+	// Use the env vars to resolve the test source files,
+	// which must be provided as test data in the respective go_test target.
+	filename = filepath.Join(bazelTestSrcdir, bazelTestWorkspace, filename)
+
+	_, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return "", fmt.Errorf(bazelMissingSourceMsg, filename, bazelTestTarget)
+	}
+	return filename, nil
+}
+
+var bazelMissingSourceMsg = `
+the test source file does not exist: %s
+It appears that you are running this test under Bazel (target: %s).
+Check that your test source files are added as test data in your go_test targets.
+
+Example:
+    go_test(
+        name = "your_package_test",
+        srcs = ["your_test.go"],
+        deps = ["@tools_gotest_v3//assert"],
+        data = glob(["*_test.go"])
+    )"
+`

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -81,7 +81,6 @@ func CallExprArgs(stackIndex int) ([]ast.Expr, error) {
 				bazelTestTarget,
 			)
 		}
-
 	}
 
 	fileset := token.NewFileSet()

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -73,9 +73,9 @@ func CallExprArgs(stackIndex int) ([]ast.Expr, error) {
 					"example:\n"+
 					"    go_test(\n"+
 					"        name = \"your_package_test\",\n"+
-					"	     srcs = [\"your_test.go\"],\n"+
-					"	     deps = [\"@tools_gotest_v3//assert\"],\n"+
-					"	     data = glob([\"*_test.go\"] # <====== test source files added as test data here!\n"+
+					"        srcs = [\"your_test.go\"],\n"+
+					"        deps = [\"@tools_gotest_v3//assert\"],\n"+
+					"        data = glob([\"*_test.go\"] # <====== test source files added as test data here!\n"+
 					"    )",
 				filename,
 				bazelTestTarget,

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -21,7 +21,7 @@ import (
 //
 // Due to Bazel's compilation and sandboxing strategy,
 // some care is required to handle resolving the original *.go source file.
-var inBazelTest bool = os.Getenv("BAZEL_TEST") == "1"
+var inBazelTest = os.Getenv("BAZEL_TEST") == "1"
 
 // The name of the target being tested (ex: //some_package:some_package_test)
 var bazelTestTarget = os.Getenv("TEST_TARGET")

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -14,24 +14,6 @@ import (
 	"runtime"
 )
 
-// These Bazel env vars are documented here:
-// https://bazel.build/reference/test-encyclopedia
-
-// Signifies test executable is being driven by `bazel test`.
-//
-// Due to Bazel's compilation and sandboxing strategy,
-// some care is required to handle resolving the original *.go source file.
-var inBazelTest = os.Getenv("BAZEL_TEST") == "1"
-
-// The name of the target being tested (ex: //some_package:some_package_test)
-var bazelTestTarget = os.Getenv("TEST_TARGET")
-
-// Absolute path to the base of the runfiles tree
-var bazelTestSrcdir = os.Getenv("TEST_SRCDIR")
-
-// The local repository's workspace name (ex: __main__)
-var bazelTestWorkspace = os.Getenv("TEST_WORKSPACE")
-
 // FormattedCallExprArg returns the argument from an ast.CallExpr at the
 // index in the call stack. The argument is formatted using FormatNode.
 func FormattedCallExprArg(stackIndex int, argPos int) (string, error) {
@@ -60,26 +42,10 @@ func CallExprArgs(stackIndex int) ([]ast.Expr, error) {
 	// (otherwise, since Bazel uses a random tmp dir for compile and sandboxing,
 	// the resulting binaries would change across compiles/test runs).
 	if inBazelTest && !filepath.IsAbs(filename) {
-		// Use the env vars to resolve the test source files,
-		// which must be provided as test data in the respective go_test target.
-		filename = filepath.Join(bazelTestSrcdir, bazelTestWorkspace, filename)
-
-		_, err := os.Stat(filename)
-		if os.IsNotExist(err) {
-			return nil, fmt.Errorf(
-				"the test source file does not exist: %s\n"+
-					"it appears that you are running this test under Bazel (target: %s);\n"+
-					"check that your test source files are added as test data in your go_test targets.\n"+
-					"example:\n"+
-					"    go_test(\n"+
-					"        name = \"your_package_test\",\n"+
-					"        srcs = [\"your_test.go\"],\n"+
-					"        deps = [\"@tools_gotest_v3//assert\"],\n"+
-					"        data = glob([\"*_test.go\"] # <====== test source files added as test data here!\n"+
-					"    )",
-				filename,
-				bazelTestTarget,
-			)
+		var err error
+		filename, err = bazelSourcePath(filename)
+		if err != nil {
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
Note that I still need to run the tests, but I wanted to get this PR open ASAP.

This PR fixes https://github.com/gotestyourself/gotest.tools/issues/274.

Now, when running under `bazel test` we'll see the following sort of error message when the target test source file can't be found:

```
--- FAIL: TestAssertShouldWorkUnderBazel (0.00s)
    your_test.go:40: the test source file does not exist: /private/var/tmp/_bazel_charles/99cf13450b07a7c7594bbbe785fbd4ef/sandbox/darwin-sandbox/20/execroot/__main__/bazel-out/darwin_arm64-fastbuild/bin/some_package/your_package_test_/your_package_test.runfiles/__main__/some_package/your_test.go
        it appears that you are running this test under Bazel (target: //some_package:your_package_test);
        check that your test source files are added as test data in your go_test targets.
        example:
            go_test(
                name = "your_package_test",
                     srcs = ["your_test.go"],
                     deps = ["@tools_gotest_v3//assert"],
                     data = glob(["*_test.go"] # <====== test source files added as test data here!
            )
    your_test.go:40: assertion failed: but assert failed to find the expression to print: a should equal b
FAIL
```

If the user adds the test source file to their test data in the respective `go_test` target, they'll now see something like:

```
--- FAIL: TestAssertShouldWorkUnderBazel (0.00s)
    your_test.go:40: assertion failed: a is not b: a should equal b
FAIL
```