### PR TITLE
poll: Continue(): use format.Message for formatting

### DIFF
--- a/poll/poll.go
+++ b/poll/poll.go
@@ -9,6 +9,7 @@ import (
 
 	"gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/internal/assert"
+	"gotest.tools/v3/internal/format"
 )
 
 // TestingT is the subset of [testing.T] used by [WaitOn]
@@ -90,7 +91,7 @@ func (r result) Error() error {
 // polling. The message text will be used as the failure message if the timeout
 // is reached.
 func Continue(message string, args ...interface{}) Result {
-	return result{message: fmt.Sprintf(message, args...)}
+	return result{message: format.Message(append([]interface{}{message}, args...)...)}
 }
 
 // Success returns a [Result] where Done() returns true, which indicates to [WaitOn]

--- a/poll/poll_test.go
+++ b/poll/poll_test.go
@@ -22,6 +22,33 @@ func (t *fakeT) Log(args ...interface{}) {}
 
 func (t *fakeT) Logf(format string, args ...interface{}) {}
 
+func TestContinueMessage(t *testing.T) {
+	tests := []struct {
+		msg      string
+		args     []interface{}
+		expected string
+	}{
+		{
+			msg:      "literal message",
+			expected: "literal message",
+		},
+		{
+			msg:      "templated %s",
+			args:     []interface{}{"message"},
+			expected: "templated message",
+		},
+		{
+			msg:      "literal message with percentage symbols (%USERPROFILE%)",
+			expected: "literal message with percentage symbols (%USERPROFILE%)",
+		},
+	}
+
+	for _, tc := range tests {
+		actual := Continue(tc.msg, tc.args...).Message()
+		assert.Check(t, cmp.Equal(tc.expected, actual))
+	}
+}
+
 func TestWaitOn(t *testing.T) {
 	counter := 0
 	end := 4


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/48359#discussion_r1725526167

Current versions of govet check for printf functions called with a format
string, but no arguments. This results in linting errors for uses of Continue
with a fixed message, for example:

    poll/poll.go:154:18: printf: non-constant format string in call to gotest.tools/v3/poll.Continue (govet)
        return Continue(buf.String())
                        ^

While not explicitly called out in the function's GoDoc, I think the intent
was to provide the same behavior as the msgAndArgs arguments in the assert
package, which allows for either a literal message (or value), or a format
with arguments to be passed.

Accepting a non-string variable as first argument would require a change
of the function's signature, but we can use the format.Message function
internally to fix the linting issue.