### PR TITLE
go.mod: update dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ workflows:
                 git config --global core.autocrlf false
                 git config --global core.symlinks true
             - run: |
-                choco upgrade golang
+                choco install golang --allow-downgrade --version=1.20
                 echo 'export PATH="$PATH:/c/Program Files/Go/bin"' > $BASH_ENV
             - run: go version
             - run: go install gotest.tools/gotestsum@latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,6 @@ workflows:
                 git config --global core.autocrlf false
                 git config --global core.symlinks true
             - run: |
-                choco install golang --allow-downgrade --version=1.20
                 echo 'export PATH="$PATH:/c/Program Files/Go/bin"' > $BASH_ENV
             - run: go version
             - run: go install gotest.tools/gotestsum@latest

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module gotest.tools/v3
 go 1.17
 
 require (
-	github.com/google/go-cmp v0.5.9
+	github.com/google/go-cmp v0.6.0
 	golang.org/x/tools v0.13.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=


### PR DESCRIPTION
### go.mod: github.com/google/go-cmp v0.6.0

Update the minimum required version; this removes the purego fallbacks.

full diff: https://github.com/google/go-cmp/compare/v0.5.9...v0.6.0
