### PR TITLE
fix TestFromDirSymlink on Windows due to missing drive-letter

### DIFF
--- a/fs/ops_test.go
+++ b/fs/ops_test.go
@@ -3,7 +3,6 @@ package fs_test
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -31,14 +30,8 @@ func TestFromDirSymlink(t *testing.T) {
 	dir := fs.NewDir(t, "test-from-dir", fs.FromDir("testdata/copy-test-with-symlink"))
 	defer dir.Remove()
 
-	currentdir, err := os.Getwd()
-	assert.NilError(t, err)
-
 	link2 := filepath.FromSlash("../2")
-	link3 := "/some/inexistent/link"
-	if runtime.GOOS == "windows" {
-		link3 = filepath.Join(filepath.VolumeName(currentdir), link3)
-	}
+	link3 := filepath.FromSlash("/some/inexistent/link")
 
 	expected := fs.Expected(t,
 		fs.WithFile("1", "1\n"),


### PR DESCRIPTION
This test was failing, because it expected the drive-letter to always
be returned, which wasn't the case;

    === FAIL: fs TestFromDirSymlink (0.01s)
        ops_test.go:55: assertion failed: directory C:\Users\circleci\AppData\Local\Temp\test-from-dir-2260318643 does not match expected:
            \a\b\3
              target: expected C:\some\inexistent\link got \some\inexistent\link

This patch removes the special-case from d44953da5fd92b6e954684d9fbc989a5be762bec,
which unconditionally added the drive-letter. Instead, we only change
the check to use the expected directory-separator.