### PR TITLE
assert, assert/cmp: un-deprecate assert.ErrorType for now

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -284,8 +284,6 @@ func ErrorContains(t TestingT, err error, substring string, msgAndArgs ...interf
 // must be called from the goroutine running the test function, not from other
 // goroutines created during the test. Use [Check] with [cmp.ErrorType] from other
 // goroutines.
-//
-// Deprecated: Use [ErrorIs]
 func ErrorType(t TestingT, err error, expected interface{}, msgAndArgs ...interface{}) {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()

--- a/assert/cmp/compare.go
+++ b/assert/cmp/compare.go
@@ -286,6 +286,7 @@ func isNil(obj interface{}, msgFunc func(reflect.Value) string) Comparison {
 }
 
 // ErrorType succeeds if err is not nil and is of the expected type.
+// New code should use [ErrorIs] instead.
 //
 // Expected can be one of:
 //
@@ -306,8 +307,6 @@ func isNil(obj interface{}, msgFunc func(reflect.Value) string) Comparison {
 //	reflect.Type
 //
 // Fails if err does not implement the [reflect.Type].
-//
-// Deprecated: Use [ErrorIs]
 func ErrorType(err error, expected interface{}) Comparison {
 	return func() Result {
 		switch expectedType := expected.(type) {


### PR DESCRIPTION
- closes https://github.com/gotestyourself/gotest.tools/issues/272
- updates https://github.com/gotestyourself/gotest.tools/pull/254
- relates to https://github.com/docker/cli/pull/5312



Commit 043b5794574c597257f7801eb14456aba5452849 deprecated these functions, marking assert.ErrorIs as a replacement. Unfortunately, assert.ErrorIs is not a drop-in replacement for various situations, or requires quite some additional boilerplating to be used.

This patch reverts the deprecation for now, but keeps recommendations in place to consider ErrorIs for situations that allow it.