### PR TITLE
poll: fix flaky TestWaitOn_WithCompare

### DIFF
--- a/poll/poll_test.go
+++ b/poll/poll_test.go
@@ -108,7 +108,7 @@ func TestWaitOn_WithCompare(t *testing.T) {
 	}
 
 	assert.Assert(t, cmp.Panics(func() {
-		WaitOn(fakeT, check, WithDelay(0), WithTimeout(10*time.Millisecond))
+		WaitOn(fakeT, check, WithDelay(0), WithTimeout(time.Second))
 	}))
 	assert.Assert(t, cmp.Contains(fakeT.failed, "assertion failed: 3 (int) != 4 (int)"))
 }


### PR DESCRIPTION
Increase the timeout in TestWaitOn_WithCompare to avoid racing the first poll attempt on slow or heavily loaded systems.


It was flaky in CI;

```
=== Failed
=== FAIL: poll TestWaitOn_WithCompare (0.01s)
    poll_test.go:113: assertion failed: string "timeout hit after 10ms: first check never completed" does not contain "assertion failed: 3 (int) != 4 (int)"
```